### PR TITLE
feat: implement Canvas LMS integration (#31)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,4 +32,5 @@ coverage.xml
 .vscode/
 
 .logs/
+
 docs/huy

--- a/src/docere/integrations/lms/canvas.py
+++ b/src/docere/integrations/lms/canvas.py
@@ -191,9 +191,9 @@ class CanvasAdapter(LMSAdapter):
                 description=a.get("description"),
                 due_at=a.get("due_at"),
                 points_possible=a.get("points_possible"),
-                assignment_type=a.get("submission_types", [None])[0]
-                if a.get("submission_types")
-                else None,
+                assignment_type=(
+                    a["submission_types"][0] if a.get("submission_types") else None
+                ),
             )
             for a in data
             if isinstance(a, dict)

--- a/src/docere/integrations/lms/canvas.py
+++ b/src/docere/integrations/lms/canvas.py
@@ -191,9 +191,7 @@ class CanvasAdapter(LMSAdapter):
                 description=a.get("description"),
                 due_at=a.get("due_at"),
                 points_possible=a.get("points_possible"),
-                assignment_type=(
-                    a["submission_types"][0] if a.get("submission_types") else None
-                ),
+                assignment_type=(a["submission_types"][0] if a.get("submission_types") else None),
             )
             for a in data
             if isinstance(a, dict)
@@ -243,9 +241,7 @@ class CanvasAdapter(LMSAdapter):
         # (e.g. concurrent student + observer enrollments) and we only want
         # to hit the profile endpoint once per user.
         unique_user_ids = list({str(e["user_id"]) for e in enrollments_raw})
-        emails = await asyncio.gather(
-            *[self._fetch_user_email(uid) for uid in unique_user_ids]
-        )
+        emails = await asyncio.gather(*[self._fetch_user_email(uid) for uid in unique_user_ids])
         email_by_user_id = dict(zip(unique_user_ids, emails, strict=True))
 
         return [
@@ -334,46 +330,48 @@ class CanvasAdapter(LMSAdapter):
                     if not file_id or file_id in seen_file_ids:
                         continue
                     seen_file_ids.add(file_id)
-                    content, content_hash = await self._extract_file_content(
-                        course_id, file_id
+                    content, content_hash = await self._extract_file_content(course_id, file_id)
+                    materials.append(
+                        LMSCourseMaterial(
+                            external_id=file_id,
+                            title=title,
+                            material_type="file",
+                            content=content,
+                            content_hash=content_hash,
+                            url=item.get("html_url"),
+                        )
                     )
-                    materials.append(LMSCourseMaterial(
-                        external_id=file_id,
-                        title=title,
-                        material_type="file",
-                        content=content,
-                        content_hash=content_hash,
-                        url=item.get("html_url"),
-                    ))
 
                 elif item_type == "Page":
                     page_url = item.get("page_url", "")
                     if not page_url:
                         continue
-                    content, content_hash = await self._fetch_page_content(
-                        course_id, page_url
+                    content, content_hash = await self._fetch_page_content(course_id, page_url)
+                    materials.append(
+                        LMSCourseMaterial(
+                            external_id=page_url,
+                            title=title,
+                            material_type="page",
+                            content=content,
+                            content_hash=content_hash,
+                            url=item.get("html_url"),
+                        )
                     )
-                    materials.append(LMSCourseMaterial(
-                        external_id=page_url,
-                        title=title,
-                        material_type="page",
-                        content=content,
-                        content_hash=content_hash,
-                        url=item.get("html_url"),
-                    ))
 
                 else:
                     # Assignment, Discussion, ExternalUrl, ExternalTool, Quiz — metadata only
-                    materials.append(LMSCourseMaterial(
-                        external_id=str(item.get("id", "")),
-                        title=title,
-                        material_type=item_type.lower(),
-                        url=item.get("html_url"),
-                    ))
+                    materials.append(
+                        LMSCourseMaterial(
+                            external_id=str(item.get("id", "")),
+                            title=title,
+                            material_type=item_type.lower(),
+                            url=item.get("html_url"),
+                        )
+                    )
 
         return materials
 
-    async def get_effective_due_dates(self, course_id: str) -> dict:
+    async def get_effective_due_dates(self, course_id: str) -> dict[str, Any]:
         """Get per-student effective due dates for all assignments in a course.
 
         Canvas endpoint: GET /api/v1/courses/:id/effective_due_dates
@@ -416,9 +414,7 @@ class CanvasAdapter(LMSAdapter):
         try:
             content = await self._download_and_extract_pdf(download_url)
         except Exception:
-            logger.warning(
-                "Canvas PDF extraction failed", file_id=file_id, url=download_url
-            )
+            logger.warning("Canvas PDF extraction failed", file_id=file_id, url=download_url)
             return None, None
 
         if not content:
@@ -470,9 +466,7 @@ class CanvasAdapter(LMSAdapter):
                 # Reject oversize files before downloading (when possible)
                 content_length = response.headers.get("content-length")
                 if content_length and int(content_length) > MAX_PDF_SIZE:
-                    logger.warning(
-                        "Canvas PDF too large, skipping", url=url, size=content_length
-                    )
+                    logger.warning("Canvas PDF too large, skipping", url=url, size=content_length)
                     return None
 
                 # Stream the PDF with size enforcement

--- a/src/docere/integrations/lms/canvas.py
+++ b/src/docere/integrations/lms/canvas.py
@@ -14,9 +14,14 @@ Key endpoints:
 - GET /api/v1/courses/:id/quizzes - quizzes
 """
 
+import asyncio
+import hashlib
+import io
+from collections.abc import Mapping
 from typing import Any
 
 import httpx
+import structlog
 
 from docere.config import settings
 from docere.integrations.lms.base import (
@@ -28,6 +33,17 @@ from docere.integrations.lms.base import (
     LMSSubmission,
 )
 
+logger = structlog.get_logger()
+
+MAX_PDF_SIZE = 20 * 1024 * 1024  # 20 MB — match Moodle adapter limit
+
+# Canvas enrollment type → normalized role
+ROLE_MAP = {
+    "StudentEnrollment": "student",
+    "TeacherEnrollment": "teacher",
+    "TaEnrollment": "ta",
+}
+
 
 class CanvasAdapter(LMSAdapter):
     """Canvas LMS integration via REST API."""
@@ -36,26 +52,38 @@ class CanvasAdapter(LMSAdapter):
         self.base_url = (base_url or settings.canvas_base_url).rstrip("/")
         self.api_token = api_token or settings.canvas_api_token
         self.headers = {"Authorization": f"Bearer {self.api_token}"}
+        # Canvas rate limit: 25-token bucket, 5/sec refill. Cap concurrency at 5.
+        self._semaphore = asyncio.Semaphore(5)
 
-    async def _get(self, path: str, params: dict[str, str] | None = None) -> object:
+    async def _get(
+        self,
+        path: str,
+        params: Mapping[str, str | list[str]] | None = None,
+    ) -> object:
         """Make authenticated GET request to Canvas API."""
-        async with httpx.AsyncClient() as client:
-            response = await client.get(
-                f"{self.base_url}/api/v1{path}",
-                headers=self.headers,
-                params=params or {},
-            )
-            response.raise_for_status()
-            return response.json()
+        async with self._semaphore:
+            async with httpx.AsyncClient() as client:
+                response = await client.get(
+                    f"{self.base_url}/api/v1{path}",
+                    headers=self.headers,
+                    params=params,
+                )
+                response.raise_for_status()
+                return response.json()
 
-    async def _get_paginated(self, path: str, params: dict[str, str] | None = None) -> list[object]:
+    async def _get_paginated(
+        self,
+        path: str,
+        params: Mapping[str, str | list[str]] | None = None,
+    ) -> list[object]:
         """Make paginated GET request, following Link headers."""
         results: list[object] = []
         url = f"{self.base_url}/api/v1{path}"
         async with httpx.AsyncClient() as client:
             while url:
-                response = await client.get(url, headers=self.headers, params=params)
-                response.raise_for_status()
+                async with self._semaphore:
+                    response = await client.get(url, headers=self.headers, params=params)
+                    response.raise_for_status()
                 results.extend(response.json())
                 # Follow pagination
                 link_header = response.headers.get("Link", "")
@@ -136,8 +164,11 @@ class CanvasAdapter(LMSAdapter):
         }
 
     async def get_course(self, course_id: str) -> LMSCourse:
-        """Get course details including syllabus body."""
-        data = await self._get(f"/courses/{course_id}", {"include[]": "syllabus_body"})
+        """Get course details including syllabus body and term."""
+        data = await self._get(
+            f"/courses/{course_id}",
+            {"include[]": ["syllabus_body", "term"]},
+        )
         assert isinstance(data, dict)
         return LMSCourse(
             external_id=str(data["id"]),
@@ -148,8 +179,11 @@ class CanvasAdapter(LMSAdapter):
         )
 
     async def get_assignments(self, course_id: str) -> list[LMSAssignment]:
-        """Get all assignments for a course."""
-        data = await self._get_paginated(f"/courses/{course_id}/assignments")
+        """Get all assignments for a course, ordered by due date."""
+        data = await self._get_paginated(
+            f"/courses/{course_id}/assignments",
+            {"include[]": ["submission"], "order_by": "due_at"},
+        )
         return [
             LMSAssignment(
                 external_id=str(a["id"]),
@@ -173,7 +207,7 @@ class CanvasAdapter(LMSAdapter):
             path = f"/courses/{course_id}/assignments/{assignment_id}/submissions"
         else:
             path = f"/courses/{course_id}/students/submissions"
-        data = await self._get_paginated(path, {"include[]": "assignment"})
+        data = await self._get_paginated(path)
         return [
             LMSSubmission(
                 external_id=str(s["id"]),
@@ -190,22 +224,59 @@ class CanvasAdapter(LMSAdapter):
         ]
 
     async def get_enrollments(self, course_id: str) -> list[LMSEnrollment]:
-        """Get student roster for a course."""
-        data = await self._get_paginated(
-            f"/courses/{course_id}/enrollments",
-            {"type[]": "StudentEnrollment"},
+        """Get course enrollments (students, teachers, TAs) with emails.
+
+        Two-phase fetch:
+        1. List enrollments — returns user_id, type, role, and a minimal nested
+           user object (id/name/short_name only — no email).
+        2. For each unique user_id, fetch the user profile to get primary_email.
+           Profile calls run concurrently and are throttled by the semaphore.
+
+        Uses the `type` field (API-stable: StudentEnrollment, TeacherEnrollment,
+        TaEnrollment, DesignerEnrollment, ObserverEnrollment) rather than `role`
+        because admins can override `role` with custom role names.
+        """
+        data = await self._get_paginated(f"/courses/{course_id}/enrollments")
+        enrollments_raw = [e for e in data if isinstance(e, dict)]
+
+        # Dedup user IDs — the same user may have multiple enrollment rows
+        # (e.g. concurrent student + observer enrollments) and we only want
+        # to hit the profile endpoint once per user.
+        unique_user_ids = list({str(e["user_id"]) for e in enrollments_raw})
+        emails = await asyncio.gather(
+            *[self._fetch_user_email(uid) for uid in unique_user_ids]
         )
+        email_by_user_id = dict(zip(unique_user_ids, emails, strict=True))
+
         return [
             LMSEnrollment(
                 user_id=str(e["user_id"]),
                 course_id=course_id,
-                role="student",
+                role=ROLE_MAP.get(e.get("type", ""), "student"),
                 name=e.get("user", {}).get("name", ""),
-                email=e.get("user", {}).get("email"),
+                email=email_by_user_id.get(str(e["user_id"])),
             )
-            for e in data
-            if isinstance(e, dict)
+            for e in enrollments_raw
         ]
+
+    async def _fetch_user_email(self, user_id: str) -> str | None:
+        """Fetch a user's primary email via the Canvas Profile endpoint.
+
+        Canvas endpoint: GET /api/v1/users/:id/profile → returns
+        { id, name, primary_email, time_zone, ... }.
+        Returns None on failure (graceful degradation — caller still creates
+        the enrollment row, just without email).
+        """
+        try:
+            data = await self._get(f"/users/{user_id}/profile")
+        except Exception:
+            logger.warning("Failed to fetch Canvas user profile", user_id=user_id)
+            return None
+
+        if not isinstance(data, dict):
+            return None
+
+        return data.get("primary_email") or None
 
     async def get_user_courses(self, user_id: str) -> list[LMSCourse]:
         """Get all courses a user is enrolled in via Canvas."""
@@ -224,39 +295,208 @@ class CanvasAdapter(LMSAdapter):
         ]
 
     async def get_course_materials(self, course_id: str) -> list[LMSCourseMaterial]:
-        """Get all course materials: modules, files, pages."""
-        materials: list[LMSCourseMaterial] = []
+        """Get all course materials by walking the Modules tree.
 
-        # Get modules with items
+        For each module item:
+        - File: fetch file metadata, download PDF if applicable, extract text via pypdf
+        - Page: fetch HTML body via the Pages API
+        - Assignment / Discussion / ExternalUrl / ExternalTool / Quiz: metadata only
+        - SubHeader: skipped (visual divider, no content)
+
+        Files are deduplicated by Canvas file ID — the same file linked in multiple
+        modules produces a single material record. SHA256 content_hash on extracted
+        content enables incremental sync to skip re-embedding unchanged materials.
+        """
+        materials: list[LMSCourseMaterial] = []
+        seen_file_ids: set[str] = set()
+
         modules = await self._get_paginated(
             f"/courses/{course_id}/modules",
             {"include[]": "items"},
         )
-        for mod in modules:
-            if not isinstance(mod, dict):
-                continue
-            for item in mod.get("items", []):
-                if isinstance(item, dict):
-                    materials.append(
-                        LMSCourseMaterial(
-                            external_id=str(item.get("id", "")),
-                            title=item.get("title", ""),
-                            material_type=item.get("type", "module_item").lower(),
-                            url=item.get("html_url"),
-                        )
-                    )
 
-        # Get files
-        files = await self._get_paginated(f"/courses/{course_id}/files")
-        for f in files:
-            if isinstance(f, dict):
-                materials.append(
-                    LMSCourseMaterial(
-                        external_id=str(f.get("id", "")),
-                        title=f.get("display_name", ""),
-                        material_type="file",
-                        url=f.get("url"),
+        for module in modules:
+            if not isinstance(module, dict):
+                continue
+            for item in module.get("items", []):
+                if not isinstance(item, dict):
+                    continue
+
+                item_type = item.get("type", "")
+                title = item.get("title", "")
+
+                if item_type == "SubHeader":
+                    # Visual divider only — no content to ingest
+                    continue
+
+                if item_type == "File":
+                    file_id = str(item.get("content_id", ""))
+                    if not file_id or file_id in seen_file_ids:
+                        continue
+                    seen_file_ids.add(file_id)
+                    content, content_hash = await self._extract_file_content(
+                        course_id, file_id
                     )
-                )
+                    materials.append(LMSCourseMaterial(
+                        external_id=file_id,
+                        title=title,
+                        material_type="file",
+                        content=content,
+                        content_hash=content_hash,
+                        url=item.get("html_url"),
+                    ))
+
+                elif item_type == "Page":
+                    page_url = item.get("page_url", "")
+                    if not page_url:
+                        continue
+                    content, content_hash = await self._fetch_page_content(
+                        course_id, page_url
+                    )
+                    materials.append(LMSCourseMaterial(
+                        external_id=page_url,
+                        title=title,
+                        material_type="page",
+                        content=content,
+                        content_hash=content_hash,
+                        url=item.get("html_url"),
+                    ))
+
+                else:
+                    # Assignment, Discussion, ExternalUrl, ExternalTool, Quiz — metadata only
+                    materials.append(LMSCourseMaterial(
+                        external_id=str(item.get("id", "")),
+                        title=title,
+                        material_type=item_type.lower(),
+                        url=item.get("html_url"),
+                    ))
 
         return materials
+
+    async def get_effective_due_dates(self, course_id: str) -> dict:
+        """Get per-student effective due dates for all assignments in a course.
+
+        Canvas endpoint: GET /api/v1/courses/:id/effective_due_dates
+        Returns mapping of { assignment_id: { student_id: { due_at, grading_period_id } } }.
+
+        Useful for the tutoring agent when due dates are overridden per-student
+        (extensions, accommodations). Not part of the abstract LMSAdapter
+        interface — Canvas-specific extension.
+        """
+        data = await self._get(f"/courses/{course_id}/effective_due_dates")
+        assert isinstance(data, dict)
+        return data
+
+    async def _extract_file_content(
+        self, course_id: str, file_id: str
+    ) -> tuple[str | None, str | None]:
+        """Fetch Canvas file metadata; if it's a PDF, download and extract text.
+
+        Returns (content, content_hash). Both None when the file is not a PDF
+        or extraction fails (graceful degradation — caller still saves the
+        material row, just without content/embedding).
+        """
+        try:
+            file_data = await self._get(f"/courses/{course_id}/files/{file_id}")
+        except Exception:
+            logger.warning("Failed to fetch Canvas file metadata", file_id=file_id)
+            return None, None
+
+        if not isinstance(file_data, dict):
+            return None, None
+
+        # Canvas Files API uses "content-type" (hyphenated, matching the HTTP header).
+        # Some implementations also expose "content_type" — check both.
+        content_type = file_data.get("content-type") or file_data.get("content_type", "")
+        download_url = file_data.get("url", "")
+
+        if content_type != "application/pdf" or not download_url:
+            return None, None
+
+        try:
+            content = await self._download_and_extract_pdf(download_url)
+        except Exception:
+            logger.warning(
+                "Canvas PDF extraction failed", file_id=file_id, url=download_url
+            )
+            return None, None
+
+        if not content:
+            return None, None
+
+        content_hash = hashlib.sha256(content.encode()).hexdigest()
+        return content, content_hash
+
+    async def _fetch_page_content(
+        self, course_id: str, page_url: str
+    ) -> tuple[str | None, str | None]:
+        """Fetch a Canvas page's HTML body via the Pages API.
+
+        Canvas endpoint: GET /api/v1/courses/:id/pages/:url_or_id → returns
+        page object whose `body` field contains the HTML content.
+        Returns (body_html, content_hash). Both None on failure.
+        """
+        try:
+            page_data = await self._get(f"/courses/{course_id}/pages/{page_url}")
+        except Exception:
+            logger.warning("Failed to fetch Canvas page", page_url=page_url)
+            return None, None
+
+        if not isinstance(page_data, dict):
+            return None, None
+
+        body = page_data.get("body") or ""
+        if not body:
+            return None, None
+
+        content_hash = hashlib.sha256(body.encode()).hexdigest()
+        return body, content_hash
+
+    async def _download_and_extract_pdf(self, url: str) -> str | None:
+        """Download a Canvas-hosted PDF and extract its text.
+
+        Uses Authorization: Bearer header for auth (Canvas's standard, unlike
+        Moodle which appends ?token=). Streams the response and enforces a
+        20 MB size limit. Returns None on failure or if no extractable text.
+        """
+        from pypdf import PdfReader
+
+        async with httpx.AsyncClient() as client:
+            async with client.stream(
+                "GET", url, headers=self.headers, follow_redirects=True
+            ) as response:
+                response.raise_for_status()
+
+                # Reject oversize files before downloading (when possible)
+                content_length = response.headers.get("content-length")
+                if content_length and int(content_length) > MAX_PDF_SIZE:
+                    logger.warning(
+                        "Canvas PDF too large, skipping", url=url, size=content_length
+                    )
+                    return None
+
+                # Stream the PDF with size enforcement
+                chunks: list[bytes] = []
+                total_size = 0
+                async for chunk in response.aiter_bytes(chunk_size=8192):
+                    total_size += len(chunk)
+                    if total_size > MAX_PDF_SIZE:
+                        logger.warning("Canvas PDF exceeded size limit", url=url)
+                        return None
+                    chunks.append(chunk)
+
+        pdf_bytes = b"".join(chunks)
+        if not pdf_bytes:
+            return None
+
+        try:
+            reader = PdfReader(io.BytesIO(pdf_bytes))
+            text_parts: list[str] = []
+            for page in reader.pages:
+                page_text = page.extract_text()
+                if page_text:
+                    text_parts.append(page_text)
+            return "\n".join(text_parts) if text_parts else None
+        except Exception:
+            logger.warning("Failed to parse Canvas PDF", url=url)
+            return None

--- a/tests/unit/test_canvas_adapter.py
+++ b/tests/unit/test_canvas_adapter.py
@@ -58,7 +58,7 @@ def _build_minimal_pdf(text: str) -> bytes:
     pdf += b"xref\n0 " + str(size).encode() + b"\n"
     pdf += b"0000000000 65535 f \n"
     for off in offsets:
-        pdf += ("%010d 00000 n \n" % off).encode()
+        pdf += f"{off:010d} 00000 n \n".encode()
     pdf += b"trailer\n<< /Size " + str(size).encode() + b" /Root 1 0 R >>\n"
     pdf += b"startxref\n" + str(xref_pos).encode() + b"\n%%EOF"
     return pdf

--- a/tests/unit/test_canvas_adapter.py
+++ b/tests/unit/test_canvas_adapter.py
@@ -1,0 +1,532 @@
+"""Transport-level tests for the Canvas LMS adapter.
+
+These exercise the *real* httpx stack (URL building, Bearer auth header, query
+params, and Link-header pagination) by injecting an ``httpx.MockTransport`` into
+the adapter's inline ``httpx.AsyncClient`` calls. Only Canvas's HTTP responses
+are faked — every line of ``canvas.py`` runs unmodified.
+
+Fixture JSON shapes are copied from the official Canvas REST API docs
+(developerdocs.instructure.com) so the mocks match reality:
+- Enrollment nested ``user`` has NO email/login_id  → validates the two-phase
+  profile fetch in ``get_enrollments``.
+- File metadata uses the hyphenated ``content-type`` key (a Canvas quirk).
+- ModuleItem uses ``content_id`` (files) and ``page_url`` (pages).
+- User Profile carries ``primary_email``.
+"""
+
+import httpx
+import pytest
+
+from docere.integrations.lms import canvas as canvas_mod
+from docere.integrations.lms.canvas import CanvasAdapter
+
+BASE_URL = "https://canvas.test"
+API = f"{BASE_URL}/api/v1"
+TOKEN = "test-token"
+COURSE_ID = "123"
+
+
+# ── Real (minimal) PDF builder ──────────────────────────────────────────────
+
+
+def _build_minimal_pdf(text: str) -> bytes:
+    """Assemble a valid single-page PDF with extractable text.
+
+    Byte offsets in the xref table are computed so pypdf parses it without
+    falling back to xref reconstruction.
+    """
+    objects = [
+        b"<< /Type /Catalog /Pages 2 0 R >>",
+        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
+        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+        b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
+    ]
+    stream = b"BT /F1 24 Tf 72 700 Td (" + text.encode("latin-1") + b") Tj ET"
+    objects.append(
+        b"<< /Length " + str(len(stream)).encode() + b" >>\nstream\n" + stream + b"\nendstream"
+    )
+    objects.append(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
+
+    pdf = b"%PDF-1.4\n"
+    offsets: list[int] = []
+    for i, obj in enumerate(objects, start=1):
+        offsets.append(len(pdf))
+        pdf += str(i).encode() + b" 0 obj\n" + obj + b"\nendobj\n"
+
+    xref_pos = len(pdf)
+    size = len(objects) + 1
+    pdf += b"xref\n0 " + str(size).encode() + b"\n"
+    pdf += b"0000000000 65535 f \n"
+    for off in offsets:
+        pdf += ("%010d 00000 n \n" % off).encode()
+    pdf += b"trailer\n<< /Size " + str(size).encode() + b" /Root 1 0 R >>\n"
+    pdf += b"startxref\n" + str(xref_pos).encode() + b"\n%%EOF"
+    return pdf
+
+
+PDF_TEXT = "Lecture 4: Merge Sort"
+PDF_BYTES = _build_minimal_pdf(PDF_TEXT)
+
+
+# ── Canvas fixture data (shapes from official docs) ─────────────────────────
+
+COURSE_JSON = {
+    "id": 123,
+    "name": "Algorithms",
+    "course_code": "CS201",
+    "syllabus_body": "<p>syllabus html</p>",
+    "term": {"id": 34, "name": "Fall 2026", "start_at": "2026-08-01T00:00:00Z"},
+}
+
+ASSIGNMENTS_JSON = [
+    {
+        "id": 4,
+        "name": "Problem Set 1",
+        "description": "<p>Do the following</p>",
+        "due_at": "2026-09-01T23:59:00Z",
+        "points_possible": 12.0,
+        "submission_types": ["online_upload"],
+    },
+    {
+        "id": 5,
+        "name": "Problem Set 2",
+        "description": None,
+        "due_at": None,
+        "points_possible": 20.0,
+        "submission_types": [],
+    },
+]
+
+SUBMISSIONS_JSON = [
+    {
+        "id": 134,
+        "assignment_id": 4,
+        "user_id": 10,
+        "score": 11.0,
+        "grade": "A-",
+        "submitted_at": "2026-09-01T01:00:00Z",
+        "graded_at": "2026-09-02T03:05:34Z",
+        "workflow_state": "graded",
+    }
+]
+
+# Enrollments split across two pages to exercise Link-header pagination.
+# Note: nested `user` has NO email — must be fetched via /users/:id/profile.
+ENROLLMENTS_PAGE_1 = [
+    {
+        "id": 1,
+        "user_id": 10,
+        "course_id": 123,
+        "type": "StudentEnrollment",
+        "role": "StudentEnrollment",
+        "user": {"id": 10, "name": "Alice Student", "short_name": "Alice"},
+    },
+    {
+        "id": 2,
+        "user_id": 11,
+        "course_id": 123,
+        "type": "TeacherEnrollment",
+        "role": "TeacherEnrollment",
+        "user": {"id": 11, "name": "Bob Teacher", "short_name": "Bob"},
+    },
+]
+ENROLLMENTS_PAGE_2 = [
+    {
+        # Custom role name — `role` is "Lab TA" but `type` is canonical.
+        "id": 3,
+        "user_id": 12,
+        "course_id": 123,
+        "type": "TaEnrollment",
+        "role": "Lab TA",
+        "user": {"id": 12, "name": "Carol TA", "short_name": "Carol"},
+    },
+    {
+        # Duplicate of Alice (same user_id) — must NOT cause a 2nd profile fetch.
+        "id": 4,
+        "user_id": 10,
+        "course_id": 123,
+        "type": "StudentEnrollment",
+        "role": "StudentEnrollment",
+        "user": {"id": 10, "name": "Alice Student", "short_name": "Alice"},
+    },
+]
+
+PROFILES = {
+    "10": {"id": 10, "name": "Alice Student", "primary_email": "alice@test.edu"},
+    "11": {"id": 11, "name": "Bob Teacher", "primary_email": "bob@test.edu"},
+    # 12 intentionally errors (handled below) → email None (graceful degradation)
+}
+
+USER_COURSES_JSON = [
+    {"id": 123, "name": "Algorithms", "course_code": "CS201"},
+    {"id": 456, "name": "Data Structures", "course_code": "CS101"},
+]
+
+MODULES_JSON = [
+    {
+        "id": 201,
+        "name": "Week 1",
+        "items": [
+            {"id": 101, "type": "File", "title": "Syllabus PDF",
+             "content_id": 777, "html_url": f"{BASE_URL}/courses/123/files/777"},
+            {"id": 102, "type": "Page", "title": "Welcome",
+             "page_url": "welcome", "html_url": f"{BASE_URL}/courses/123/pages/welcome"},
+            {"id": 103, "type": "SubHeader", "title": "Readings"},
+            {"id": 104, "type": "Assignment", "title": "Problem Set 1",
+             "content_id": 4, "html_url": f"{BASE_URL}/courses/123/assignments/4"},
+        ],
+    },
+    {
+        "id": 202,
+        "name": "Week 2",
+        "items": [
+            {"id": 105, "type": "File", "title": "Notes (txt)",
+             "content_id": 778, "html_url": f"{BASE_URL}/courses/123/files/778"},
+            # Duplicate of file 777 in another module → deduped away.
+            {"id": 106, "type": "File", "title": "Syllabus again",
+             "content_id": 777, "html_url": f"{BASE_URL}/courses/123/files/777"},
+        ],
+    },
+]
+
+FILES = {
+    "777": {
+        "id": 777, "display_name": "syllabus.pdf", "filename": "syllabus.pdf",
+        "content-type": "application/pdf",
+        "url": "https://files.canvas.test/files/777/download?download_frd=1",
+        "size": len(PDF_BYTES),
+    },
+    "778": {
+        "id": 778, "display_name": "notes.txt", "filename": "notes.txt",
+        "content-type": "text/plain",
+        "url": "https://files.canvas.test/files/778/download?download_frd=1",
+        "size": 10,
+    },
+}
+
+PAGE_WELCOME = {
+    "page_id": 1, "url": "welcome", "title": "Welcome",
+    "body": "<p>Welcome to the course</p>", "published": True,
+}
+
+EFFECTIVE_DUE_DATES = {
+    "4": {"10": {"due_at": "2026-09-03T23:59:00Z", "grading_period_id": None}}
+}
+
+ASSIGNMENT_GROUPS = [
+    {
+        "id": 1, "name": "Homework", "position": 1,
+        "assignments": [
+            {"id": 4, "name": "Problem Set 1", "points_possible": 12.0},
+            {"id": 5, "name": "Problem Set 2", "points_possible": 20.0},
+        ],
+    },
+    {
+        "id": 2, "name": "Exams", "position": 2,
+        "assignments": [{"id": 6, "name": "Midterm", "points_possible": 100.0}],
+    },
+]
+
+
+# ── MockTransport router + fixture ──────────────────────────────────────────
+
+
+class CanvasMock:
+    """Holds the adapter plus a log of every request the handler saw."""
+
+    def __init__(self, adapter: CanvasAdapter):
+        self.adapter = adapter
+        self.requests: list[httpx.Request] = []
+
+    def paths(self, method: str | None = None) -> list[str]:
+        return [
+            r.url.path for r in self.requests
+            if method is None or r.method == method
+        ]
+
+
+def _make_handler(mock: CanvasMock):
+    def handler(request: httpx.Request) -> httpx.Response:
+        mock.requests.append(request)
+        path = request.url.path
+        method = request.method
+        params = request.url.params
+
+        # ── PDF / file downloads (separate host) ──
+        if path.endswith("/download"):
+            if path.endswith("/777/download"):
+                return httpx.Response(200, content=PDF_BYTES)
+            return httpx.Response(200, content=b"plain text body")
+
+        if method == "GET":
+            # GET /courses/:id  (single course)
+            if path == "/api/v1/courses/123":
+                return httpx.Response(200, json=COURSE_JSON)
+            if path == "/api/v1/courses/123/assignments":
+                return httpx.Response(200, json=ASSIGNMENTS_JSON)
+            if path == "/api/v1/courses/123/assignments/4/submissions":
+                return httpx.Response(200, json=SUBMISSIONS_JSON)
+            if path == "/api/v1/courses/123/students/submissions":
+                return httpx.Response(200, json=SUBMISSIONS_JSON)
+            if path == "/api/v1/courses/123/enrollments":
+                if params.get("page") == "2":
+                    return httpx.Response(200, json=ENROLLMENTS_PAGE_2)
+                next_url = f"{API}/courses/123/enrollments?page=2"
+                return httpx.Response(
+                    200, json=ENROLLMENTS_PAGE_1,
+                    headers={"Link": f'<{next_url}>; rel="next"'},
+                )
+            if path.startswith("/api/v1/users/") and path.endswith("/profile"):
+                uid = path.split("/")[4]
+                if uid in PROFILES:
+                    return httpx.Response(200, json=PROFILES[uid])
+                return httpx.Response(500, json={"errors": ["boom"]})
+            if path == "/api/v1/users/10/courses":
+                return httpx.Response(200, json=USER_COURSES_JSON)
+            if path == "/api/v1/courses/123/modules":
+                return httpx.Response(200, json=MODULES_JSON)
+            if path.startswith("/api/v1/courses/123/files/"):
+                fid = path.split("/")[-1]
+                return httpx.Response(200, json=FILES[fid])
+            if path.startswith("/api/v1/courses/123/pages/"):
+                return httpx.Response(200, json=PAGE_WELCOME)
+            if path == "/api/v1/courses/123/effective_due_dates":
+                return httpx.Response(200, json=EFFECTIVE_DUE_DATES)
+            if path == "/api/v1/courses/123/assignment_groups":
+                return httpx.Response(200, json=ASSIGNMENT_GROUPS)
+
+        if method == "PUT" and "/submissions/" in path:
+            return httpx.Response(200, json={"id": 1, "grade": "95"})
+
+        if method == "POST" and path.endswith("/discussion_topics"):
+            return httpx.Response(200, json={
+                "id": 99, "title": "T", "message": "m",
+                "html_url": f"{BASE_URL}/courses/123/discussion_topics/99",
+                "is_announcement": True, "published": True,
+            })
+
+        return httpx.Response(404, json={"errors": [f"unrouted {method} {path}"]})
+
+    return handler
+
+
+@pytest.fixture
+def canvas(monkeypatch) -> CanvasMock:
+    adapter = CanvasAdapter(BASE_URL, TOKEN)
+    mock = CanvasMock(adapter)
+    transport = httpx.MockTransport(_make_handler(mock))
+    real_client = httpx.AsyncClient
+
+    def client_factory(*args, **kwargs):
+        kwargs.setdefault("transport", transport)
+        return real_client(*args, **kwargs)
+
+    monkeypatch.setattr(canvas_mod.httpx, "AsyncClient", client_factory)
+    return mock
+
+
+# ── Plumbing: auth header, params, pagination ───────────────────────────────
+
+
+async def test_bearer_auth_header_sent_on_every_request(canvas):
+    await canvas.adapter.get_course(COURSE_ID)
+    assert canvas.requests, "no requests captured"
+    for req in canvas.requests:
+        assert req.headers["Authorization"] == f"Bearer {TOKEN}"
+
+
+async def test_get_course_sends_include_params_and_parses_term(canvas):
+    course = await canvas.adapter.get_course(COURSE_ID)
+    assert course.term == "Fall 2026"
+    assert course.external_id == "123"
+    assert course.course_code == "CS201"
+    # include[]=syllabus_body,term must be on the wire
+    includes = canvas.requests[0].url.params.get_list("include[]")
+    assert set(includes) == {"syllabus_body", "term"}
+
+
+async def test_pagination_follows_link_header(canvas):
+    enrollments = await canvas.adapter.get_enrollments(COURSE_ID)
+    # 2 raw rows page1 + 2 rows page2 = 4 enrollment rows
+    assert len(enrollments) == 4
+    enrollment_paths = [
+        r.url for r in canvas.requests if r.url.path.endswith("/enrollments")
+    ]
+    assert len(enrollment_paths) == 2
+    assert str(enrollment_paths[1]).endswith("page=2")
+
+
+# ── get_enrollments: two-phase fetch, dedup, type-not-role ──────────────────
+
+
+async def test_enrollments_roles_use_type_not_custom_role(canvas):
+    enrollments = await canvas.adapter.get_enrollments(COURSE_ID)
+    by_user = {e.user_id: e for e in enrollments}
+    assert by_user["10"].role == "student"
+    assert by_user["11"].role == "teacher"
+    # Carol's `role` is the custom "Lab TA" — must still map to ta via `type`.
+    assert by_user["12"].role == "ta"
+
+
+async def test_enrollments_emails_from_profile_endpoint(canvas):
+    enrollments = await canvas.adapter.get_enrollments(COURSE_ID)
+    by_user = {e.user_id: e for e in enrollments}
+    assert by_user["10"].email == "alice@test.edu"
+    assert by_user["11"].email == "bob@test.edu"
+    # Profile fetch for user 12 errors → graceful degradation to None.
+    assert by_user["12"].email is None
+
+
+async def test_enrollments_dedups_profile_fetches(canvas):
+    await canvas.adapter.get_enrollments(COURSE_ID)
+    profile_calls = [p for p in canvas.paths("GET") if p.endswith("/profile")]
+    # 3 unique users (10, 11, 12) despite Alice appearing in 2 enrollment rows.
+    assert len(profile_calls) == 3
+
+
+# ── get_assignments / get_submissions ───────────────────────────────────────
+
+
+async def test_get_assignments_params_and_mapping(canvas):
+    assignments = await canvas.adapter.get_assignments(COURSE_ID)
+    assert [a.external_id for a in assignments] == ["4", "5"]
+    assert assignments[0].assignment_type == "online_upload"
+    # Empty submission_types → assignment_type None (no IndexError).
+    assert assignments[1].assignment_type is None
+    params = canvas.requests[0].url.params
+    assert params.get_list("include[]") == ["submission"]
+    assert params.get("order_by") == "due_at"
+
+
+async def test_get_submissions_for_assignment_uses_scoped_path(canvas):
+    subs = await canvas.adapter.get_submissions(COURSE_ID, assignment_id="4")
+    assert len(subs) == 1
+    assert subs[0].student_id == "10"
+    assert subs[0].score == 11.0
+    assert canvas.paths("GET") == ["/api/v1/courses/123/assignments/4/submissions"]
+
+
+async def test_get_submissions_course_wide_path(canvas):
+    await canvas.adapter.get_submissions(COURSE_ID)
+    assert canvas.paths("GET") == ["/api/v1/courses/123/students/submissions"]
+
+
+async def test_get_user_courses(canvas):
+    courses = await canvas.adapter.get_user_courses("10")
+    assert {c.external_id for c in courses} == {"123", "456"}
+
+
+# ── get_course_materials: modules walk, dispatch, dedup, extraction ─────────
+
+
+async def test_course_materials_dispatch_and_dedup(canvas):
+    materials = await canvas.adapter.get_course_materials(COURSE_ID)
+    by_id = {m.external_id: m for m in materials}
+    # SubHeader skipped; duplicate file 777 deduped → File(777), Page, Assignment, File(778)
+    assert len(materials) == 4
+    assert by_id["777"].material_type == "file"
+    assert by_id["welcome"].material_type == "page"
+    # Metadata-only items key off the module item id (104), not content_id.
+    assert by_id["104"].material_type == "assignment"
+
+
+async def test_course_materials_pdf_extracted_with_hash(canvas):
+    materials = await canvas.adapter.get_course_materials(COURSE_ID)
+    pdf = next(m for m in materials if m.external_id == "777")
+    assert pdf.content is not None
+    assert "Merge Sort" in pdf.content
+    assert pdf.content_hash is not None
+    assert len(pdf.content_hash) == 64
+
+
+async def test_course_materials_non_pdf_has_no_content(canvas):
+    materials = await canvas.adapter.get_course_materials(COURSE_ID)
+    txt = next(m for m in materials if m.external_id == "778")
+    assert txt.content is None
+    assert txt.content_hash is None
+
+
+async def test_course_materials_page_body_extracted(canvas):
+    materials = await canvas.adapter.get_course_materials(COURSE_ID)
+    page = next(m for m in materials if m.external_id == "welcome")
+    assert page.content == "<p>Welcome to the course</p>"
+    assert len(page.content_hash) == 64
+
+
+async def test_course_materials_metadata_only_item_has_no_content(canvas):
+    materials = await canvas.adapter.get_course_materials(COURSE_ID)
+    assignment = next(m for m in materials if m.external_id == "104")
+    assert assignment.content is None
+
+
+# ── PDF size guard + graceful degradation ───────────────────────────────────
+
+
+async def test_pdf_size_limit_rejects_oversize_file(canvas, monkeypatch):
+    monkeypatch.setattr(canvas_mod, "MAX_PDF_SIZE", 10)
+    content = await canvas.adapter._download_and_extract_pdf(
+        FILES["777"]["url"]
+    )
+    assert content is None
+
+
+async def test_file_metadata_failure_degrades_gracefully(canvas):
+    # Unknown file id → handler returns 404 inside files/, _get raises,
+    # _extract_file_content swallows it and returns (None, None).
+    content, content_hash = await canvas.adapter._extract_file_content(
+        COURSE_ID, "99999"
+    )
+    assert content is None and content_hash is None
+
+
+# ── Read paths: effective due dates, grade items ────────────────────────────
+
+
+async def test_get_effective_due_dates(canvas):
+    data = await canvas.adapter.get_effective_due_dates(COURSE_ID)
+    assert data["4"]["10"]["due_at"] == "2026-09-03T23:59:00Z"
+
+
+async def test_get_grade_items_flattens_groups_with_category(canvas):
+    items = await canvas.adapter.get_grade_items(COURSE_ID)
+    assert {i["id"] for i in items} == {"4", "5", "6"}
+    by_id = {i["id"]: i for i in items}
+    assert by_id["4"]["category"] == "Homework"
+    assert by_id["6"]["category"] == "Exams"
+    assert by_id["6"]["grade_max"] == 100.0
+
+
+# ── Write paths: save_grade, post_announcement ──────────────────────────────
+
+
+async def test_save_grade_sends_posted_grade_and_comment(canvas):
+    result = await canvas.adapter.save_grade(
+        COURSE_ID, "4", "10", 95.0, feedback="Nice work"
+    )
+    assert result == {"success": True}
+    put_req = next(r for r in canvas.requests if r.method == "PUT")
+    import json
+    body = json.loads(put_req.content)
+    assert body["submission"]["posted_grade"] == "95.0"
+    assert body["comment"]["text_comment"] == "Nice work"
+
+
+async def test_post_announcement_returns_id_and_url(canvas):
+    result = await canvas.adapter.post_announcement(
+        COURSE_ID, "Heads up", "Class cancelled"
+    )
+    assert result["id"] == "99"
+    assert result["url"].endswith("/discussion_topics/99")
+    post_req = next(r for r in canvas.requests if r.method == "POST")
+    import json
+    body = json.loads(post_req.content)
+    assert body["is_announcement"] is True
+
+
+# ── Error propagation ───────────────────────────────────────────────────────
+
+
+async def test_non_2xx_raises(canvas):
+    # /courses/999 is unrouted → 404 → raise_for_status propagates.
+    with pytest.raises(httpx.HTTPStatusError):
+        await canvas.adapter.get_course("999")


### PR DESCRIPTION
## Summary

Completes the Canvas LMS adapter so Canvas courses sync the same way Moodle courses already do. The stub could authenticate and list objects, but it pulled no file/page content (the tutoring agent had zero Canvas course knowledge) and only saw students (no teachers/TAs, no emails). This PR adds real content extraction, full-roster enrollment sync, fixes several silent data bugs, and adds a full transport-level test suite.

Everything is contained to one integration file plus its tests. Nothing in the sync service, background tasks, LTI launch, or API routes needed to change, since they already treat Canvas and Moodle through the same `LMSAdapter` interface.
Closes #31 

---

## Issues

Two blocking gaps and several silent bugs in `CanvasAdapter`:

| Problem | Impact |
|---|---|
| `get_course_materials()` returned metadata only (`content=None` always) | Qdrant got nothing for Canvas courses, so the agent had zero course knowledge |
| `get_enrollments()` filtered to `StudentEnrollment` and read a non-existent `user.email` | No instructors/TAs synced, and every student email was `null` |
| `get_course()` never requested `include[]=term` | `LMSCourse.term` was always `None` |
| `get_assignments()` sent no ordering/include params | Unordered results, no submission state |
| `get_submissions()` sent `include[]=assignment` | Full assignment object pulled every sync and discarded immediately (wasted bandwidth) |

---

## What changed

All in [`src/docere/integrations/lms/canvas.py`](../../src/docere/integrations/lms/canvas.py).

### 1. `get_course_materials()`: real content extraction (the main work)

Before: walked modules for metadata, then dumped a flat file list, never fetching any content.

```python
for item in mod.get("items", []):
    materials.append(LMSCourseMaterial(
        external_id=str(item.get("id", "")),
        title=item.get("title", ""),
        material_type=item.get("type", "module_item").lower(),
        url=item.get("html_url"),
    ))            # content is always None
# ...then a second flat /files pass, also metadata-only
```

After: walks the modules tree and dispatches per item type, extracting text.

```python
for module in modules:
    for item in module.get("items", []):
        item_type = item.get("type", "")
        if item_type == "SubHeader":
            continue                                   # visual divider, skip
        if item_type == "File":
            file_id = str(item.get("content_id", ""))  # stable Canvas file id
            if not file_id or file_id in seen_file_ids:
                continue                               # dedup across modules
            seen_file_ids.add(file_id)
            content, content_hash = await self._extract_file_content(course_id, file_id)
            # PDF: stream-download (Bearer auth, 20 MB cap) + pypdf text extract
        elif item_type == "Page":
            content, content_hash = await self._fetch_page_content(course_id, page_url)
            # GET /pages/:url, take the HTML `body`
        else:
            ...                                        # Assignment/Quiz/etc: metadata only
```

Design choices (mirrors the Moodle adapter): walk modules, not the flat files API, so the module title stays as semantic context. PDFs only for now. SHA256 `content_hash` drives incremental-sync skip logic. Graceful degradation: a failed download logs a warning and stores `content=None` instead of aborting the whole sync.

### 2. `get_enrollments()`: full roster + emails (two-phase fetch)

Before: students only, and `user.email` doesn't exist on the enrollment payload.

```python
data = await self._get_paginated(
    f"/courses/{course_id}/enrollments", {"type[]": "StudentEnrollment"},
)
return [LMSEnrollment(..., role="student",
                      email=e.get("user", {}).get("email")) ...]  # always None
```

After: all roles, plus a concurrent profile fetch for the real email.

```python
data = await self._get_paginated(f"/courses/{course_id}/enrollments")
unique_user_ids = list({str(e["user_id"]) for e in enrollments_raw})
emails = await asyncio.gather(*[self._fetch_user_email(uid) for uid in unique_user_ids])
# role from the API-stable `type` field, not the customizable `role` field:
role=ROLE_MAP.get(e.get("type", ""), "student")
```

The nested `user` object on an enrollment carries only `{id, name, sortable_name, short_name}` (confirmed in the Canvas docs), so the email has to come from `GET /users/:id/profile` (`primary_email`). Fetches are deduped per user and throttled by the existing semaphore. Role mapping uses `type` (`StudentEnrollment`/`TeacherEnrollment`/`TaEnrollment`) because an admin can rename `role` to a custom string (e.g. "Lab TA"), which would otherwise misclassify a TA as a student.

### 3. Smaller fixes

| Method | Change |
|---|---|
| `get_course()` | Send `include[]=syllabus_body,term`; parse `term.name` (was always `None`) |
| `get_assignments()` | Send `include[]=submission` and `order_by=due_at`; guard empty `submission_types` |
| `get_submissions()` | Drop the discarded `include[]=assignment` param |
| `get_effective_due_dates()` | New Canvas-only helper for per-student due-date overrides |
| `_get` / `_get_paginated` | Gated by `asyncio.Semaphore(5)` as a defensive concurrency cap |

---

## Files changed

| File | Change |
|---|---|
| `src/docere/integrations/lms/canvas.py` | +290 / -49, all of the above |
| `tests/unit/test_canvas_adapter.py` | New: 22 transport-level tests |
| `.gitignore` | +1: ignore `/docs/huy` (personal working notes) |

---

## How this was tested

The whole suite is pure unit tests: no Docker, no Postgres/Redis/Qdrant, no network, no Canvas instance. Run it anywhere:

```bash
source .venv/Scripts/activate
python -m pytest tests/unit/test_canvas_adapter.py -v
# 22 passed in 0.58s
```

### Approach: real httpx stack, faked responses

Rather than stubbing the adapter's methods, the tests inject an [`httpx.MockTransport`](https://www.python-httpx.org/advanced/transports/#mock-transports) into the adapter's inline `httpx.AsyncClient`. The real HTTP machinery still runs: URL building, the `Authorization: Bearer` header, query params, and `Link: rel="next"` pagination parsing are all exercised. Only Canvas's JSON responses are canned:

```python
@pytest.fixture
def canvas(monkeypatch):
    adapter = CanvasAdapter(BASE_URL, TOKEN)
    transport = httpx.MockTransport(_make_handler(mock))   # routes by method + path
    real_client = httpx.AsyncClient
    def client_factory(*args, **kwargs):
        kwargs.setdefault("transport", transport)
        return real_client(*args, **kwargs)
    monkeypatch.setattr(canvas_mod.httpx, "AsyncClient", client_factory)
    return mock
```

PDF extraction is tested end to end with a real, hand-built single-page PDF (no `reportlab`/`fpdf` in the dep tree, so the fixture assembles valid PDF bytes with correct xref offsets). `pypdf` actually parses it, and we assert the extracted text and the 64-char content hash.

### Coverage

Every adapter method, including the edge cases the bugs above hid:

- **Plumbing**: Bearer header on every request; `include[]` params on the wire; pagination follows the `Link` header across two enrollment pages
- **Enrollments**: `type`-not-`role` mapping (custom "Lab TA" maps to `ta`); emails from the profile endpoint; profile-fetch dedup (3 calls for 4 rows); profile 500 degrades to `email=None`
- **Materials**: File/Page/Assignment/SubHeader dispatch; file dedup across modules; real PDF text + hash; non-PDF stays `content=None`; page body extraction; PDF size guard; metadata-fetch failure degradation
- **Reads**: `get_course` term parsing; `get_assignments` params and empty `submission_types`; `get_submissions` scoped vs course-wide paths; `get_user_courses`; `get_effective_due_dates`; `get_grade_items` group-to-category flattening
- **Writes**: `save_grade` (posted_grade + comment body); `post_announcement` (is_announcement flag)
- **Errors**: non-2xx propagates as `HTTPStatusError`

### Why no live Canvas test, and why this is safe to merge
https://github.com/instructure/canvas-lms/wiki/Quick-Start The official Canvas Docs noted that:
The official Docker dev setup needs 150GB of available hard drive space, 8GB of RAM, a quad-core CPU, and a long multi-step build (web + Postgres + Redis + jobs), and ships no seed script, so test courses/files/users have to be created by hand. That's too heavy to stand up just to validate an adapter, and we don't have a hosted sandbox yet.

This is still safe to merge because:

1. **The blast radius is tiny.** One integration file. The orchestration layer is unchanged and already proven against Moodle.
2. **Every fixture shape comes from the official Canvas API docs** (cited below). The tests assert against documented response shapes, so they're unlikely to diverge from a real instance.
3. **Once a Canvas sandbox exists**, anyone can run the manual smoke test: point the adapter at the instance and call `get_course`, `get_enrollments`, and `get_course_materials` against a real course. The doc-grounded unit tests already cover the parsing/dispatch logic; the live run only needs to confirm connectivity and auth.

---

## Out of scope (follow-up issues)

1. **Persistent `httpx.AsyncClient`**: share one client across calls (needs the adapters to become async context managers). Roughly 2 to 3x sync speedup.
2. **More file types**: `.docx`/`.pptx`/`.txt` extraction (Canvas + Moodle).
3. **Webhooks / Live Events**: Canvas Live Events + Moodle notifications to trigger `run_lti_material_sync()` on change, replacing the 2-hour poll.

---

## Sources

API shapes and behavior were verified against the official Canvas documentation:

| Topic | Source |
|---|---|
| Enrollments (nested `user` has no email; `type` vs `role`) | https://developerdocs.instructure.com/services/canvas/resources/enrollments |
| Modules / ModuleItem (`content_id`, `page_url`, item types) | https://developerdocs.instructure.com/services/canvas/resources/modules |
| Files (hyphenated `content-type`, download `url`) | https://developerdocs.instructure.com/services/canvas/resources/files |
| Pages (`body` field) | https://developerdocs.instructure.com/services/canvas/resources/pages |
| Courses (`include[]=term`) | https://developerdocs.instructure.com/services/canvas/resources/courses |
| Assignments (`order_by`, `submission_types`) | https://developerdocs.instructure.com/services/canvas/resources/assignments |
| Assignment Groups (`include[]=assignments`) | https://developerdocs.instructure.com/services/canvas/resources/assignment_groups |
| Submissions | https://developerdocs.instructure.com/services/canvas/resources/submissions |
| User Profile (`primary_email`) | https://developerdocs.instructure.com/services/canvas/resources/users |
| Discussion Topics (announcements) | https://developerdocs.instructure.com/services/canvas/resources/discussion_topics |
| Pagination (`Link` header) | https://canvas.instructure.com/doc/api/file.pagination.html |
| Throttling (concurrency cap rationale) | https://developerdocs.instructure.com/services/canvas/basics/file.throttling |
| Community reference implementation | https://github.com/vishalsachdev/canvas-mcp |
| Self-host feasibility (Docker dev setup) | https://github.com/instructure/canvas-lms/blob/master/doc/docker/developing_with_docker.md |
| Testing tool | [httpx MockTransport](https://www.python-httpx.org/advanced/transports/#mock-transports) |

> Note for reviewers: I keep a personal `docs/huy/` folder (gitignored) with deeper working notes: a codebase overview, the full phased implementation plan, and an API audit (issues found vs research, with citations). Happy to send these over if any of the reasoning above needs more context.

---

## Reviewer notes

Running the broader unit suite surfaces 6 failures in `test_enhanced_strategy_evolution.py` and `test_llm_stream.py`. These are pre-existing and unrelated to this PR (they fail identically without this file loaded). Flagging so they aren't mistaken for regressions from this change.
