### PR TITLE
fix: frontend lint tests ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - run: npm run lint
-      - run: npx tsc --noEmit
+      - run: npx tsc -b --noEmit
 
   frontend-build:
     name: Frontend Build

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -19,5 +19,12 @@ export default defineConfig([
       ecmaVersion: 2020,
       globals: globals.browser,
     },
+    rules: {
+      'no-empty': ['error', { allowEmptyCatch: true }],
+      'react-refresh/only-export-components': [
+        'error',
+        { allowConstantExport: true, allowExportNames: ['useAuth', 'Icons', 'studentColor'] },
+      ],
+    },
   },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -28,6 +28,7 @@
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
+        "@types/three": "^0.182.0",
         "@vitejs/plugin-react": "^5.1.1",
         "eslint": "^9.39.1",
         "eslint-plugin-react-hooks": "^7.0.1",
@@ -331,6 +332,13 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@dimforge/rapier3d-compat": {
+      "version": "0.12.0",
+      "resolved": "https://registry.npmjs.org/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz",
+      "integrity": "sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==",
+      "dev": true,
+      "license": "Apache-2.0"
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.27.3",
@@ -2543,10 +2551,47 @@
         "@types/react": "^19.2.0"
       }
     },
+    "node_modules/@types/stats.js": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/stats.js/-/stats.js-0.17.4.tgz",
+      "integrity": "sha512-jIBvWWShCvlBqBNIZt0KAshWpvSjhkwkEu4ZUcASoAvhmrgAUI2t1dXrjSL4xXVLB4FznPrIsX3nKXFl/Dt4vA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/three": {
+      "version": "0.182.0",
+      "resolved": "https://registry.npmjs.org/@types/three/-/three-0.182.0.tgz",
+      "integrity": "sha512-WByN9V3Sbwbe2OkWuSGyoqQO8Du6yhYaXtXLoA5FkKTUJorZ+yOHBZ35zUUPQXlAKABZmbYp5oAqpA4RBjtJ/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@dimforge/rapier3d-compat": "~0.12.0",
+        "@tweenjs/tween.js": "~23.1.3",
+        "@types/stats.js": "*",
+        "@types/webxr": ">=0.5.17",
+        "@webgpu/types": "*",
+        "fflate": "~0.8.2",
+        "meshoptimizer": "~0.22.0"
+      }
+    },
+    "node_modules/@types/three/node_modules/@tweenjs/tween.js": {
+      "version": "23.1.3",
+      "resolved": "https://registry.npmjs.org/@tweenjs/tween.js/-/tween.js-23.1.3.tgz",
+      "integrity": "sha512-vJmvvwFxYuGnF2axRtPYocag6Clbb5YS7kLL+SO/TeVFzHqDIWrNKYtcsPMibjDx9O+bu+psAy9NKfWklassUA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/use-sync-external-store": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/@types/use-sync-external-store/-/use-sync-external-store-0.0.6.tgz",
       "integrity": "sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/webxr": {
+      "version": "0.5.24",
+      "resolved": "https://registry.npmjs.org/@types/webxr/-/webxr-0.5.24.tgz",
+      "integrity": "sha512-h8fgEd/DpoS9CBrjEQXR+dIDraopAEfu4wYVNY2tEPwk60stPWhvZMf4Foo5FakuQ7HFZoa8WceaWFervK2Ovg==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -2838,6 +2883,13 @@
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.70",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.70.tgz",
+      "integrity": "sha512-LFiNHHKMvmAEvwVew3JLJmTdShhbdwRFSImUshGhE2mGE8ybQzIo63l5uRp+YKnNx+8Qno8Kf6gN+DKMreIJCA==",
+      "dev": true,
+      "license": "BSD-3-Clause"
     },
     "node_modules/3d-force-graph": {
       "version": "1.79.1",
@@ -3664,6 +3716,13 @@
         }
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.3.tgz",
+      "integrity": "sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
@@ -4415,6 +4474,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/meshoptimizer": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/meshoptimizer/-/meshoptimizer-0.22.0.tgz",
+      "integrity": "sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/minimatch": {
       "version": "3.1.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,6 +30,7 @@
     "@types/node": "^24.10.1",
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
+    "@types/three": "^0.182.0",
     "@vitejs/plugin-react": "^5.1.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",

--- a/frontend/src/AuthContext.tsx
+++ b/frontend/src/AuthContext.tsx
@@ -12,7 +12,7 @@ const AuthContext = createContext<AuthState | null>(null)
 
 export function AuthProvider({ children }: { children: React.ReactNode }) {
   const [user, setUser] = useState<User | null>(getStoredUser)
-  const [loading, setLoading] = useState(!!getStoredToken())
+  const [loading, setLoading] = useState(true)
 
   // On mount, verify stored token or auto-login in dev mode
   useEffect(() => {
@@ -27,7 +27,6 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         .finally(() => setLoading(false))
     } else {
       // Auto dev login — skip the login page entirely
-      setLoading(true)
       devLogin('student@test.com')
         .then(data => {
           setUser({ id: data.user_id, name: data.name, email: 'student@test.com', role: data.role })

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -402,7 +402,7 @@ export async function streamMessage(
         }
       }
     }
-  } catch (err) {
+  } catch {
     // Network error or connection drop mid-stream
     if (!receivedDone) {
       onError('Connection lost — please try again.')

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -67,16 +67,12 @@ const ACTION_LABELS: Record<string, { title: string; execute: string }> = {
 }
 
 function EmailRecipientLabel({ to, courseId }: { to: string | string[]; courseId?: string }) {
-  const [label, setLabel] = useState<string | null>(null)
+  // Already a list of emails, or no group to resolve: show directly, no fetch needed
+  const staticLabel = Array.isArray(to) ? to.join(', ') : (!courseId ? to : null)
+  const [label, setLabel] = useState<string | null>(staticLabel)
 
   useEffect(() => {
-    // If it's already a list of emails, just show them
-    if (Array.isArray(to)) {
-      setLabel(to.join(', '))
-      return
-    }
-    // Resolve group target
-    if (!courseId) { setLabel(to); return }
+    if (staticLabel !== null) return
     const token = getStoredToken()
     fetch('/api/v1/integrations/resolve-recipients', {
       method: 'POST',
@@ -85,8 +81,8 @@ function EmailRecipientLabel({ to, courseId }: { to: string | string[]; courseId
     })
       .then(r => r.ok ? r.json() : null)
       .then(data => { if (data) setLabel(data.target_label) })
-      .catch(() => setLabel(to))
-  }, [to, courseId])
+      .catch(() => setLabel(to as string))
+  }, [to, courseId, staticLabel])
 
   return <span className="text-white/60">{label ?? 'Resolving...'}</span>
 }

--- a/frontend/src/components/ActionCard.tsx
+++ b/frontend/src/components/ActionCard.tsx
@@ -125,19 +125,19 @@ function ActionPreview({ action }: { action: MetaAction }) {
     case 'draft_email':
       return (
         <div className="space-y-1.5 text-[12px]">
-          {action.to && (
+          {Boolean(action.to) && (
             <div className="flex gap-2">
               <span className="text-white/25 shrink-0">To:</span>
               <EmailRecipientLabel to={action.to as string | string[]} courseId={action.course_id as string} />
             </div>
           )}
-          {action.subject && (
+          {Boolean(action.subject) && (
             <div className="flex gap-2">
               <span className="text-white/25 shrink-0">Subject:</span>
               <span className="text-white/60">{action.subject as string}</span>
             </div>
           )}
-          {action.body && (
+          {Boolean(action.body) && (
             <ExpandableEmailBody body={action.body as string} />
           )}
         </div>
@@ -147,7 +147,7 @@ function ActionPreview({ action }: { action: MetaAction }) {
       return (
         <div className="space-y-1.5 text-[12px]">
           <div className="text-white/60 font-medium">{action.title as string}</div>
-          {action.content && (
+          {Boolean(action.content) && (
             <div className="text-white/35 text-[11px] line-clamp-3 leading-relaxed">
               {(action.content as string).slice(0, 200)}...
             </div>
@@ -159,7 +159,7 @@ function ActionPreview({ action }: { action: MetaAction }) {
       return (
         <div className="space-y-1.5 text-[12px]">
           <div className="text-white/60 font-medium">{action.title as string}</div>
-          {action.headers && (
+          {Boolean(action.headers) && (
             <div className="overflow-x-auto">
               <table className="text-[10px] text-white/40 border-collapse">
                 <thead>
@@ -193,7 +193,7 @@ function ActionPreview({ action }: { action: MetaAction }) {
       return (
         <div className="space-y-1.5 text-[12px]">
           <div className="text-white/60 font-medium">{action.title as string}</div>
-          {action.headers && (
+          {Boolean(action.headers) && (
             <div className="overflow-x-auto">
               <table className="text-[10px] text-white/40 border-collapse">
                 <thead>
@@ -227,7 +227,7 @@ function ActionPreview({ action }: { action: MetaAction }) {
       return (
         <div className="space-y-1.5 text-[12px]">
           <div className="text-white/60 font-medium">{action.title as string}</div>
-          {action.message && (
+          {Boolean(action.message) && (
             <div className="text-white/35 text-[11px] line-clamp-3 leading-relaxed">
               {(action.message as string).replace(/<[^>]*>/g, '').slice(0, 200)}
             </div>
@@ -239,12 +239,12 @@ function ActionPreview({ action }: { action: MetaAction }) {
       return (
         <div className="space-y-1.5 text-[12px]">
           <div className="text-white/60 font-medium">{action.summary as string}</div>
-          {action.start && (
+          {Boolean(action.start) && (
             <div className="text-white/35 text-[11px]">
               {new Date(action.start as string).toLocaleString()} — {new Date(action.end as string).toLocaleTimeString()}
             </div>
           )}
-          {action.attendee_email && (
+          {Boolean(action.attendee_email) && (
             <div className="text-white/30 text-[11px]">With: {action.attendee_email as string}</div>
           )}
         </div>

--- a/frontend/src/components/ConceptGraph3D.tsx
+++ b/frontend/src/components/ConceptGraph3D.tsx
@@ -231,17 +231,6 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
       }
     }, [onStudentClick])
 
-    if (nodes.length === 0) {
-      return (
-        <div
-          className="flex items-center justify-center text-text-500 text-sm"
-          style={{ width, height }}
-        >
-          No data yet — students need to start chatting
-        </div>
-      )
-    }
-
     // Custom 3D objects per node type + topology
     const renderNode = useCallback((node: any) => {
       // ── Concept hub nodes (octahedron + label) ──
@@ -330,6 +319,17 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
       })
       return new THREE.Mesh(geo, mat)
     }, [topology, isDistributed])
+
+    if (nodes.length === 0) {
+      return (
+        <div
+          className="flex items-center justify-center text-text-500 text-sm"
+          style={{ width, height }}
+        >
+          No data yet — students need to start chatting
+        </div>
+      )
+    }
 
     return (
       <ForceGraph3D

--- a/frontend/src/components/ConceptGraph3D.tsx
+++ b/frontend/src/components/ConceptGraph3D.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useMemo, useEffect, forwardRef, useImperativeHandle } from 'react'
 import ForceGraph3D from 'react-force-graph-3d'
-import type { ForceGraphMethods } from 'react-force-graph-3d'
+import type { ForceGraphMethods, NodeObject, LinkObject } from 'react-force-graph-3d'
 import SpriteText from 'three-spritetext'
 import * as THREE from 'three'
 
@@ -50,6 +50,58 @@ export interface ConceptGraph3DHandle {
   zoomToFit: () => void
 }
 
+interface ConceptSceneNode {
+  id: string
+  name: string
+  nodeType: 'concept'
+  val: number
+  color: string
+  avgMastery: number
+  studentCount: number
+  timesStruggled: number
+  masteryLabel: string
+}
+
+interface StudentSceneNode {
+  id: string
+  name: string
+  nodeType: 'student'
+  val: number
+  color: string
+  engagement?: string | null
+  totalInteractions: number
+  avgConfusion: number
+}
+
+interface MemorySceneNode {
+  id: string
+  name: string
+  nodeType: 'memory'
+  val: number
+  color: string
+  memoryType?: string | null
+  concepts?: string[] | null
+  confusionScore: number
+  sentiment?: string | null
+}
+
+// d3-force mutates these in-place, adding x/y/z (and velocity) once the simulation runs
+type SceneNode = (ConceptSceneNode | StudentSceneNode | MemorySceneNode) & {
+  x?: number
+  y?: number
+  z?: number
+}
+
+interface SceneLink {
+  source: string | SceneNode
+  target: string | SceneNode
+  edgeType: GraphEdge['type']
+  weight: number | null
+}
+
+type SceneNodeObj = NodeObject<SceneNode>
+type SceneLinkObj = LinkObject<SceneNode, SceneLink>
+
 /** Student node color based on engagement level */
 export function studentColor(engagement: string | null | undefined): string {
   switch (engagement) {
@@ -94,9 +146,9 @@ function sentimentIcon(sentiment: string | null | undefined): string {
 
 export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
   function ConceptGraph3D({ nodes, edges, width, height, filter = 'all', topology = 'student', onStudentClick }, ref) {
-    const fgRef = useRef<ForceGraphMethods | undefined>(undefined)
+    const fgRef = useRef<ForceGraphMethods<SceneNodeObj, SceneLinkObj> | undefined>(undefined)
     // d3-force mutates these node objects in-place, adding x/y/z positions
-    const nodesRef = useRef<any[]>([])
+    const nodesRef = useRef<SceneNodeObj[]>([])
 
     const isDistributed = topology === 'distributed'
 
@@ -151,17 +203,18 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
     nodesRef.current = graphData.nodes
 
     // Visibility based on filter — keeps force layout stable
-    const isNodeVisible = useCallback((node: any): boolean => {
+    const isNodeVisible = useCallback((node: SceneNode): boolean => {
       if (filter === 'all') return true
       if (node.nodeType === 'student') return true
       if (filter === 'students') return false
+      if (node.nodeType === 'concept') return false
       return node.memoryType === filter
     }, [filter])
 
-    const isLinkVisible = useCallback((link: any): boolean => {
+    const isLinkVisible = useCallback((link: SceneLink): boolean => {
       if (filter === 'all') return true
-      const src = typeof link.source === 'object' ? link.source : nodesRef.current.find((n: any) => n.id === link.source)
-      const tgt = typeof link.target === 'object' ? link.target : nodesRef.current.find((n: any) => n.id === link.target)
+      const src = typeof link.source === 'object' ? link.source : nodesRef.current.find(n => n.id === link.source)
+      const tgt = typeof link.target === 'object' ? link.target : nodesRef.current.find(n => n.id === link.target)
       if (!src || !tgt) return false
       return isNodeVisible(src) && isNodeVisible(tgt)
     }, [filter, isNodeVisible])
@@ -169,13 +222,13 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
     const zoomToNode = useCallback((nodeId: string) => {
       const fg = fgRef.current
       if (!fg) return
-      const node = nodesRef.current.find((n: any) => n.id === nodeId)
-      if (!node || node.x === undefined) return
+      const node = nodesRef.current.find(n => n.id === nodeId)
+      if (!node || node.x === undefined || node.y === undefined || node.z === undefined) return
       const distance = node.nodeType === 'student' ? 150 : 80
       const distRatio = 1 + distance / Math.hypot(node.x, node.y, node.z)
       fg.cameraPosition(
         { x: node.x * distRatio, y: node.y * distRatio, z: node.z * distRatio },
-        node,
+        { x: node.x, y: node.y, z: node.z },
         1000,
       )
     }, [])
@@ -192,19 +245,19 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
       if (!fg) return
 
       // Add exponential fog — softens the void when zoomed in
-      const scene = (fg as any).scene?.()
+      const scene = fg.scene()
       if (scene) {
         scene.fog = new THREE.FogExp2('#0a0a1a', 0.0006)
       }
 
       // Subtle bloom post-processing
       try {
-        const composer = (fg as any).postProcessingComposer?.()
+        const composer = fg.postProcessingComposer()
         if (composer) {
           import('three/examples/jsm/postprocessing/UnrealBloomPass.js').then(
             ({ UnrealBloomPass }) => {
               const bloom = new UnrealBloomPass(
-                undefined as any,
+                new THREE.Vector2(256, 256),
                 0.6,   // strength — gentle glow
                 0.3,   // radius
                 0.88,  // threshold — only brightest colors bloom
@@ -218,12 +271,15 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
       }
     }, [])
 
-    const handleNodeClick = useCallback((node: any) => {
+    const handleNodeClick = useCallback((node: SceneNodeObj) => {
       const distance = node.nodeType === 'student' ? 150 : 80
-      const distRatio = 1 + distance / Math.hypot(node.x, node.y, node.z)
+      const x = node.x ?? 0
+      const y = node.y ?? 0
+      const z = node.z ?? 0
+      const distRatio = 1 + distance / Math.hypot(x, y, z)
       fgRef.current?.cameraPosition(
-        { x: node.x * distRatio, y: node.y * distRatio, z: node.z * distRatio },
-        node,
+        { x: x * distRatio, y: y * distRatio, z: z * distRatio },
+        { x, y, z },
         1000,
       )
       if (node.nodeType === 'student' && onStudentClick) {
@@ -232,7 +288,7 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
     }, [onStudentClick])
 
     // Custom 3D objects per node type + topology
-    const renderNode = useCallback((node: any) => {
+    const renderNode = useCallback((node: SceneNodeObj) => {
       // ── Concept hub nodes (octahedron + label) ──
       if (node.nodeType === 'concept') {
         const group = new THREE.Group()
@@ -332,7 +388,7 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
     }
 
     return (
-      <ForceGraph3D
+      <ForceGraph3D<SceneNode, SceneLink>
         ref={fgRef}
         graphData={graphData}
         width={width}
@@ -343,7 +399,7 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
         linkVisibility={isLinkVisible}
         // Custom node rendering
         nodeThreeObject={renderNode}
-        nodeLabel={(node: any) => {
+        nodeLabel={(node: SceneNodeObj) => {
           if (node.nodeType === 'concept') {
             return `<div style="background:rgba(0,0,0,0.9);color:#fff;padding:8px 12px;border-radius:8px;font-size:13px;max-width:240px;line-height:1.5;border:1px solid ${node.color}">
             <b style="color:${node.color}">${node.name}</b><br/>
@@ -369,20 +425,20 @@ export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
         </div>`
         }}
         // Links
-        linkWidth={(link: any) => {
+        linkWidth={(link: SceneLinkObj) => {
           if (link.edgeType === 'concept_concept') return 1
           if (link.edgeType === 'concept_student') return 1.2
           if (link.edgeType === 'student_memory') return isDistributed ? 0.8 : 1.5
           return 0.3
         }}
         linkOpacity={0.35}
-        linkColor={(link: any) => {
+        linkColor={(link: SceneLinkObj) => {
           if (link.edgeType === 'concept_concept') return '#9966ff'
           if (link.edgeType === 'concept_student') return '#44ddff'
           if (link.edgeType === 'student_memory') return '#4488ff'
           return '#553388'
         }}
-        linkDirectionalParticles={(link: any) => {
+        linkDirectionalParticles={(link: SceneLinkObj) => {
           if (link.edgeType === 'concept_student') return 1
           if (link.edgeType === 'student_memory' && !isDistributed) return 2
           return 0

--- a/frontend/src/components/ConceptGraph3D.tsx
+++ b/frontend/src/components/ConceptGraph3D.tsx
@@ -94,7 +94,7 @@ function sentimentIcon(sentiment: string | null | undefined): string {
 
 export const ConceptGraph3D = forwardRef<ConceptGraph3DHandle, Props>(
   function ConceptGraph3D({ nodes, edges, width, height, filter = 'all', topology = 'student', onStudentClick }, ref) {
-    const fgRef = useRef<ForceGraphMethods | undefined>()
+    const fgRef = useRef<ForceGraphMethods | undefined>(undefined)
     // d3-force mutates these node objects in-place, adding x/y/z positions
     const nodesRef = useRef<any[]>([])
 

--- a/frontend/src/components/DocumentChat.tsx
+++ b/frontend/src/components/DocumentChat.tsx
@@ -26,7 +26,7 @@ const SUGGESTIONS: Record<string, string[]> = {
   default: ['Summarize this document', 'What are the key points?', 'Quiz me on this'],
 }
 
-export function DocumentChat({ isOpen, onClose, courseId, docId, docName, docType }: Props) {
+export function DocumentChat({ isOpen, onClose, courseId, docName, docType }: Props) {
   const [messages, setMessages] = useState<Message[]>([])
   const [input, setInput] = useState('')
   const [loading, setLoading] = useState(false)

--- a/frontend/src/components/DocumentChat.tsx
+++ b/frontend/src/components/DocumentChat.tsx
@@ -83,11 +83,11 @@ export function DocumentChat({ isOpen, onClose, courseId, docName, docType }: Pr
           )
         },
       )
-    } catch (e: any) {
+    } catch (e) {
       setMessages(prev => [...prev, {
         id: `err-${Date.now()}`,
         role: 'assistant',
-        content: `Something went wrong: ${e.message}`,
+        content: `Something went wrong: ${e instanceof Error ? e.message : String(e)}`,
       }])
     } finally {
       setLoading(false)

--- a/frontend/src/components/DocumentReader.tsx
+++ b/frontend/src/components/DocumentReader.tsx
@@ -351,8 +351,8 @@ export function DocumentReader({ docId, courseId, onBack, onStatusChange }: Prop
       await api.confirmDocument(docId)
       setDoc(prev => prev ? { ...prev, status: 'processing' } : prev)
       onStatusChange?.()
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to confirm document')
     } finally {
       setConfirming(false)
     }

--- a/frontend/src/components/DocumentReader.tsx
+++ b/frontend/src/components/DocumentReader.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo, useCallback } from 'react'
+import { useState, useEffect, useCallback } from 'react'
 import {
   ArrowLeft, BookPlus, CheckCircle, Loader, AlertCircle, FileText,
   File, Image, Presentation, Table, ZoomIn, ZoomOut, Copy, Check,

--- a/frontend/src/components/DocumentsPanel.tsx
+++ b/frontend/src/components/DocumentsPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { X, Upload, FileText, Trash2, CheckCircle, AlertCircle, Loader, Link, File, Image, Presentation, Table, Eye } from 'lucide-react'
+import { X, Upload, FileText, Trash2, Loader, Link, File, Image, Presentation, Table } from 'lucide-react'
 import * as api from '../api'
 import type { StudentDocument } from '../api'
 
@@ -34,7 +34,7 @@ function getFileConfig(filename: string) {
 }
 
 const STATUS_CONFIG = {
-  pending:    { label: 'Queued', spinning: true },
+  uploaded:   { label: 'Queued', spinning: true },
   processing: { label: 'Indexing', spinning: true },
   completed:  { label: 'Ready', spinning: false },
   failed:     { label: 'Failed', spinning: false },
@@ -61,7 +61,7 @@ export function DocumentsPanel({ courseId, onClose }: Props) {
 
   // Poll for processing docs
   useEffect(() => {
-    const hasProcessing = docs.some(d => d.status === 'pending' || d.status === 'processing')
+    const hasProcessing = docs.some(d => d.status === 'uploaded' || d.status === 'processing')
     if (hasProcessing) {
       pollRef.current = setInterval(loadDocs, 3000)
     } else if (pollRef.current) {
@@ -232,7 +232,7 @@ export function DocumentsPanel({ courseId, onClose }: Props) {
           const fileCfg = getFileConfig(doc.filename)
           const FileIcon = fileCfg.icon
           const config = STATUS_CONFIG[doc.status]
-          const isProcessing = doc.status === 'pending' || doc.status === 'processing'
+          const isProcessing = doc.status === 'uploaded' || doc.status === 'processing'
 
           return (
             <div

--- a/frontend/src/components/DocumentsPanel.tsx
+++ b/frontend/src/components/DocumentsPanel.tsx
@@ -79,8 +79,8 @@ export function DocumentsPanel({ courseId, onClose }: Props) {
     try {
       await api.uploadDocument(courseId, file)
       await loadDocs()
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Upload failed')
     } finally {
       setUploading(false)
     }
@@ -108,8 +108,8 @@ export function DocumentsPanel({ courseId, onClose }: Props) {
       setUrlInput('')
       setShowUrlInput(false)
       await loadDocs()
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Upload failed')
     } finally {
       setUploading(false)
     }
@@ -119,8 +119,8 @@ export function DocumentsPanel({ courseId, onClose }: Props) {
     try {
       await api.deleteDocument(docId)
       setDocs(prev => prev.filter(d => d.id !== docId))
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Delete failed')
     }
   }
 

--- a/frontend/src/components/FlashcardReview.tsx
+++ b/frontend/src/components/FlashcardReview.tsx
@@ -29,7 +29,7 @@ export function FlashcardReview({ courseId, onClose }: FlashcardReviewProps) {
   const [isDragging, setIsDragging] = useState(false)
   const [exitDir, setExitDir] = useState<'left' | 'right' | null>(null)
   const startRef = useRef({ x: 0, y: 0, time: 0 })
-  const cardStartTime = useRef(Date.now())
+  const cardStartTime = useRef(0)
 
   // Load review session
   useEffect(() => {

--- a/frontend/src/components/FlashcardReview.tsx
+++ b/frontend/src/components/FlashcardReview.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef, useCallback } from 'react'
 import { X, RotateCcw, Check, Undo2 } from 'lucide-react'
 import { Icons } from './ClaudeChatInput'
 import * as api from '../api'
-import type { FlashcardCard, ReviewSession } from '../api'
+import type { ReviewSession } from '../api'
 
 interface FlashcardReviewProps {
   courseId: string

--- a/frontend/src/components/FlashcardReview.tsx
+++ b/frontend/src/components/FlashcardReview.tsx
@@ -33,7 +33,6 @@ export function FlashcardReview({ courseId, onClose }: FlashcardReviewProps) {
 
   // Load review session
   useEffect(() => {
-    setLoading(true)
     api.getReviewSession(courseId)
       .then(s => {
         setSession(s)

--- a/frontend/src/components/GradebookSyncModal.tsx
+++ b/frontend/src/components/GradebookSyncModal.tsx
@@ -124,8 +124,8 @@ function SourceStep({ source, onSelect, integrationStatus }: {
     try {
       const data = await readGoogleSpreadsheet(sheet.id)
       onSelect(data)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load spreadsheet')
     } finally {
       setLoading(false)
     }
@@ -138,8 +138,8 @@ function SourceStep({ source, onSelect, integrationStatus }: {
     try {
       const data = await readGoogleSpreadsheetUrl(urlInput.trim())
       onSelect(data)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load spreadsheet')
     } finally {
       setLoading(false)
     }
@@ -153,8 +153,8 @@ function SourceStep({ source, onSelect, integrationStatus }: {
     try {
       const result = await uploadExcel(file)
       onSelect({ title: result.filename, headers: result.headers, rows: result.rows })
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed')
     } finally {
       setLoading(false)
     }
@@ -172,8 +172,8 @@ function SourceStep({ source, onSelect, integrationStatus }: {
     try {
       const result = await uploadExcel(file)
       onSelect({ title: result.filename, headers: result.headers, rows: result.rows })
-    } catch (err: any) {
-      setError(err.message)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed')
     } finally {
       setLoading(false)
     }
@@ -368,8 +368,8 @@ function DestinationStep({ courses, sourceData, onValidate }: {
     try {
       const result = await validateGradebook(sourceData, selectedCourse, [...selectedItems])
       onValidate(selectedCourse, [...selectedItems], result)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Validation failed')
     } finally {
       setValidating(false)
     }
@@ -511,8 +511,8 @@ function ValidationStep({ result, sourceData, courseId, onSync, onFix, onBack }:
         { ...sourceData, rows: editableRows },
       )
       onSync(syncResult)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Sync failed')
     } finally {
       setSyncing(false)
     }
@@ -527,8 +527,8 @@ function ValidationStep({ result, sourceData, courseId, onSync, onFix, onBack }:
         result.issues,
       )
       onFix(fixResult)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Fix failed')
     } finally {
       setFixing(false)
     }

--- a/frontend/src/components/GradebookSyncModal.tsx
+++ b/frontend/src/components/GradebookSyncModal.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback, useRef } from 'react'
+import { useState, useEffect, useRef } from 'react'
 import type {
   Course,
   IntegrationStatus,
@@ -9,7 +9,6 @@ import type {
   ValidationIssue,
   SyncResult,
   FixResult,
-  ColumnMapping,
 } from '../api'
 import {
   listGoogleSpreadsheets,

--- a/frontend/src/components/MeetingScheduler.tsx
+++ b/frontend/src/components/MeetingScheduler.tsx
@@ -30,7 +30,6 @@ export function MeetingScheduler({ courseId, conversationId, action, onClose, on
   const [selectedSlot, setSelectedSlot] = useState<TimeSlot | null>(null)
 
   useEffect(() => {
-    setLoading(true)
     api.getAvailableSlots(courseId)
       .then(data => {
         setSlots(data)

--- a/frontend/src/components/NotesEditor.tsx
+++ b/frontend/src/components/NotesEditor.tsx
@@ -82,7 +82,7 @@ export function NotesEditor({
       return
     }
     if (content && content !== '<p></p>') {
-      editor.commands.setContent(content, false)
+      editor.commands.setContent(content, { emitUpdate: false })
     }
   }, [content, editor])
 

--- a/frontend/src/components/NotesEditor.tsx
+++ b/frontend/src/components/NotesEditor.tsx
@@ -4,7 +4,7 @@ import Placeholder from '@tiptap/extension-placeholder'
 import Highlight from '@tiptap/extension-highlight'
 import TaskList from '@tiptap/extension-task-list'
 import TaskItem from '@tiptap/extension-task-item'
-import React, { useEffect, useCallback, useRef } from 'react'
+import React, { useEffect, useRef } from 'react'
 
 interface NotesEditorProps {
   content: string
@@ -31,6 +31,33 @@ function DocereLogo({ className }: { className?: string }) {
         <use href="#nl" transform="rotate(135 100 100)"/>
       </g>
     </svg>
+  )
+}
+
+function ToolbarButton({
+  onClick,
+  isActive = false,
+  children,
+  title
+}: {
+  onClick: () => void
+  isActive?: boolean
+  children: React.ReactNode
+  title: string
+}) {
+  return (
+    <button
+      type="button"
+      onMouseDown={(e) => { e.preventDefault(); onClick() }}
+      title={title}
+      className={`w-7 h-7 flex items-center justify-center rounded text-xs transition-colors ${
+        isActive
+          ? 'bg-accent/15 text-accent'
+          : 'text-text-400 hover:text-text-200 hover:bg-bg-200/60'
+      }`}
+    >
+      {children}
+    </button>
   )
 }
 
@@ -85,31 +112,6 @@ export function NotesEditor({
       editor.commands.setContent(content, { emitUpdate: false })
     }
   }, [content, editor])
-
-  const ToolbarButton = useCallback(({
-    onClick,
-    isActive = false,
-    children,
-    title
-  }: {
-    onClick: () => void
-    isActive?: boolean
-    children: React.ReactNode
-    title: string
-  }) => (
-    <button
-      type="button"
-      onMouseDown={(e) => { e.preventDefault(); onClick() }}
-      title={title}
-      className={`w-7 h-7 flex items-center justify-center rounded text-xs transition-colors ${
-        isActive
-          ? 'bg-accent/15 text-accent'
-          : 'text-text-400 hover:text-text-200 hover:bg-bg-200/60'
-      }`}
-    >
-      {children}
-    </button>
-  ), [])
 
   if (!editor) return null
 

--- a/frontend/src/components/StudentMemoryGraph.tsx
+++ b/frontend/src/components/StudentMemoryGraph.tsx
@@ -211,17 +211,6 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
       }
     }, [onNodeClick])
 
-    if (nodes.length === 0) {
-      return (
-        <div
-          className="flex items-center justify-center text-white/40 text-sm"
-          style={{ width, height }}
-        >
-          Start chatting to build your memory map
-        </div>
-      )
-    }
-
     // Custom 3D objects
     const renderNode = useCallback((node: any) => {
       // ── Concept nodes (octahedron + label) ──
@@ -306,6 +295,17 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
       })
       return new THREE.Mesh(geo, mat)
     }, [])
+
+    if (nodes.length === 0) {
+      return (
+        <div
+          className="flex items-center justify-center text-white/40 text-sm"
+          style={{ width, height }}
+        >
+          Start chatting to build your memory map
+        </div>
+      )
+    }
 
     return (
       <ForceGraph3D

--- a/frontend/src/components/StudentMemoryGraph.tsx
+++ b/frontend/src/components/StudentMemoryGraph.tsx
@@ -1,6 +1,6 @@
 import { useRef, useCallback, useMemo, useEffect, forwardRef, useImperativeHandle } from 'react'
 import ForceGraph3D from 'react-force-graph-3d'
-import type { ForceGraphMethods } from 'react-force-graph-3d'
+import type { ForceGraphMethods, NodeObject, LinkObject } from 'react-force-graph-3d'
 import SpriteText from 'three-spritetext'
 import * as THREE from 'three'
 import type { MemoryGraphNode, MemoryGraphEdge } from '../api'
@@ -20,6 +20,65 @@ export interface StudentMemoryGraphHandle {
   zoomToNode: (nodeId: string) => void
   zoomToFit: () => void
 }
+
+interface ConceptSceneNode {
+  id: string
+  name: string
+  nodeType: 'concept'
+  rawType: 'concept'
+  val: number
+  color: string
+  masteryLevel: number
+  masteryLabel: string
+  timesPracticed: number
+  timesStruggled: number
+  _raw: MemoryGraphNode
+}
+
+interface DocumentSceneNode {
+  id: string
+  name: string
+  nodeType: 'document'
+  rawType: 'document'
+  val: number
+  color: string
+  docType?: string | null
+  status?: string | null
+  pageCount?: number | null
+  chunkCount?: number | null
+  _raw: MemoryGraphNode
+}
+
+interface MemorySceneNode {
+  id: string
+  name: string
+  nodeType: 'memory'
+  rawType: 'memory'
+  val: number
+  color: string
+  memoryType?: string | null
+  concepts?: string[] | null
+  confusionScore: number
+  sentiment?: string | null
+  _raw: MemoryGraphNode
+}
+
+// d3-force mutates these in-place, adding x/y/z (and velocity) once the simulation runs
+type SceneNode = (ConceptSceneNode | DocumentSceneNode | MemorySceneNode) & {
+  x?: number
+  y?: number
+  z?: number
+}
+
+interface SceneLink {
+  source: string | SceneNode
+  target: string | SceneNode
+  edgeType: MemoryGraphEdge['type']
+  weight: number | null
+}
+
+type SceneNodeObj = NodeObject<SceneNode>
+type SceneLinkObj = LinkObject<SceneNode, SceneLink>
 
 // ── Colors ──
 
@@ -71,8 +130,8 @@ function sentimentIcon(sentiment: string | null | undefined): string {
 
 export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
   function StudentMemoryGraph({ nodes, edges, width, height, filter = 'all', onNodeClick }, ref) {
-    const fgRef = useRef<ForceGraphMethods | undefined>(undefined)
-    const nodesRef = useRef<any[]>([])
+    const fgRef = useRef<ForceGraphMethods<SceneNodeObj, SceneLinkObj> | undefined>(undefined)
+    const nodesRef = useRef<SceneNodeObj[]>([])
 
     const graphData = useMemo(() => ({
       nodes: nodes.map(n => {
@@ -132,20 +191,20 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
     nodesRef.current = graphData.nodes
 
     // Visibility
-    const isNodeVisible = useCallback((node: any): boolean => {
+    const isNodeVisible = useCallback((node: SceneNode): boolean => {
       if (filter === 'all') return true
       if (filter === 'memories') return node.nodeType === 'memory' || node.nodeType === 'concept'
       if (filter === 'concepts') return node.nodeType === 'concept'
       if (filter === 'documents') return node.nodeType === 'document' || node.nodeType === 'concept'
-      if (filter === 'struggle') return node.nodeType === 'concept' || node.memoryType === 'struggle'
-      if (filter === 'breakthrough') return node.nodeType === 'concept' || node.memoryType === 'breakthrough'
+      if (filter === 'struggle') return node.nodeType === 'concept' || (node.nodeType === 'memory' && node.memoryType === 'struggle')
+      if (filter === 'breakthrough') return node.nodeType === 'concept' || (node.nodeType === 'memory' && node.memoryType === 'breakthrough')
       return true
     }, [filter])
 
-    const isLinkVisible = useCallback((link: any): boolean => {
+    const isLinkVisible = useCallback((link: SceneLink): boolean => {
       if (filter === 'all') return true
-      const src = typeof link.source === 'object' ? link.source : nodesRef.current.find((n: any) => n.id === link.source)
-      const tgt = typeof link.target === 'object' ? link.target : nodesRef.current.find((n: any) => n.id === link.target)
+      const src = typeof link.source === 'object' ? link.source : nodesRef.current.find(n => n.id === link.source)
+      const tgt = typeof link.target === 'object' ? link.target : nodesRef.current.find(n => n.id === link.target)
       if (!src || !tgt) return false
       return isNodeVisible(src) && isNodeVisible(tgt)
     }, [filter, isNodeVisible])
@@ -153,13 +212,13 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
     const zoomToNode = useCallback((nodeId: string) => {
       const fg = fgRef.current
       if (!fg) return
-      const node = nodesRef.current.find((n: any) => n.id === nodeId)
-      if (!node || node.x === undefined) return
+      const node = nodesRef.current.find(n => n.id === nodeId)
+      if (!node || node.x === undefined || node.y === undefined || node.z === undefined) return
       const distance = node.nodeType === 'concept' ? 150 : 100
       const distRatio = 1 + distance / Math.hypot(node.x, node.y, node.z)
       fg.cameraPosition(
         { x: node.x * distRatio, y: node.y * distRatio, z: node.z * distRatio },
-        node,
+        { x: node.x, y: node.y, z: node.z },
         1000,
       )
     }, [])
@@ -175,18 +234,18 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
       const fg = fgRef.current
       if (!fg) return
 
-      const scene = (fg as any).scene?.()
+      const scene = fg.scene()
       if (scene) {
         scene.fog = new THREE.FogExp2('#0a0a1a', 0.0006)
       }
 
       try {
-        const composer = (fg as any).postProcessingComposer?.()
+        const composer = fg.postProcessingComposer()
         if (composer) {
           import('three/examples/jsm/postprocessing/UnrealBloomPass.js').then(
             ({ UnrealBloomPass }) => {
               const bloom = new UnrealBloomPass(
-                undefined as any,
+                new THREE.Vector2(256, 256),
                 0.6,
                 0.3,
                 0.88,
@@ -198,12 +257,15 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
       } catch {}
     }, [])
 
-    const handleNodeClick = useCallback((node: any) => {
+    const handleNodeClick = useCallback((node: SceneNodeObj) => {
       const distance = node.nodeType === 'concept' ? 150 : 100
-      const distRatio = 1 + distance / Math.hypot(node.x, node.y, node.z)
+      const x = node.x ?? 0
+      const y = node.y ?? 0
+      const z = node.z ?? 0
+      const distRatio = 1 + distance / Math.hypot(x, y, z)
       fgRef.current?.cameraPosition(
-        { x: node.x * distRatio, y: node.y * distRatio, z: node.z * distRatio },
-        node,
+        { x: x * distRatio, y: y * distRatio, z: z * distRatio },
+        { x, y, z },
         1000,
       )
       if (onNodeClick && node._raw) {
@@ -212,7 +274,7 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
     }, [onNodeClick])
 
     // Custom 3D objects
-    const renderNode = useCallback((node: any) => {
+    const renderNode = useCallback((node: SceneNodeObj) => {
       // ── Concept nodes (octahedron + label) ──
       if (node.nodeType === 'concept') {
         const group = new THREE.Group()
@@ -308,7 +370,7 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
     }
 
     return (
-      <ForceGraph3D
+      <ForceGraph3D<SceneNode, SceneLink>
         ref={fgRef}
         graphData={graphData}
         width={width}
@@ -317,7 +379,7 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
         nodeVisibility={isNodeVisible}
         linkVisibility={isLinkVisible}
         nodeThreeObject={renderNode}
-        nodeLabel={(node: any) => {
+        nodeLabel={(node: SceneNodeObj) => {
           if (node.nodeType === 'concept') {
             return `<div style="background:rgba(0,0,0,0.9);color:#fff;padding:8px 12px;border-radius:8px;font-size:13px;max-width:240px;line-height:1.5;border:1px solid ${node.color}">
               <b style="color:${node.color}">${node.name}</b><br/>
@@ -345,7 +407,7 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
           </div>`
         }}
         // Links
-        linkWidth={(link: any) => {
+        linkWidth={(link: SceneLinkObj) => {
           if (link.edgeType === 'concept_concept') return 1
           if (link.edgeType === 'memory_concept') return 1.2
           if (link.edgeType === 'doc_concept') return 1.5
@@ -353,14 +415,14 @@ export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
           return 0.5
         }}
         linkOpacity={0.3}
-        linkColor={(link: any) => {
+        linkColor={(link: SceneLinkObj) => {
           if (link.edgeType === 'concept_concept') return '#9966ff'
           if (link.edgeType === 'memory_concept') return '#4488ff'
           if (link.edgeType === 'doc_concept') return '#a78bfa'
           if (link.edgeType === 'memory_memory') return '#553388'
           return '#444466'
         }}
-        linkDirectionalParticles={(link: any) => {
+        linkDirectionalParticles={(link: SceneLinkObj) => {
           if (link.edgeType === 'doc_concept') return 2
           if (link.edgeType === 'memory_concept') return 1
           return 0

--- a/frontend/src/components/StudentMemoryGraph.tsx
+++ b/frontend/src/components/StudentMemoryGraph.tsx
@@ -71,7 +71,7 @@ function sentimentIcon(sentiment: string | null | undefined): string {
 
 export const StudentMemoryGraph = forwardRef<StudentMemoryGraphHandle, Props>(
   function StudentMemoryGraph({ nodes, edges, width, height, filter = 'all', onNodeClick }, ref) {
-    const fgRef = useRef<ForceGraphMethods | undefined>()
+    const fgRef = useRef<ForceGraphMethods | undefined>(undefined)
     const nodesRef = useRef<any[]>([])
 
     const graphData = useMemo(() => ({

--- a/frontend/src/components/StudyPanel.tsx
+++ b/frontend/src/components/StudyPanel.tsx
@@ -1,4 +1,4 @@
-import { useState, useRef, useEffect, useCallback } from 'react'
+import { useState, useRef, useEffect, useCallback, type ReactElement } from 'react'
 import { X, ChevronLeft, ChevronRight, RotateCcw, BookOpen, Layers, FileText, Presentation, Pencil, Eye } from 'lucide-react'
 import type { StudyArtifact } from '../api'
 
@@ -171,8 +171,8 @@ function MarkdownLine({ line }: { line: string }) {
   return <p className="text-sm text-text-200 mb-2 leading-relaxed">{renderInline(trimmed)}</p>
 }
 
-function renderInline(text: string): (string | JSX.Element)[] {
-  const parts: (string | JSX.Element)[] = []
+function renderInline(text: string): (string | ReactElement)[] {
+  const parts: (string | ReactElement)[] = []
   let remaining = text
   let key = 0
   while (remaining) {

--- a/frontend/src/components/StudyPanel.tsx
+++ b/frontend/src/components/StudyPanel.tsx
@@ -61,7 +61,7 @@ export function StudyPanel({ artifact, isGenerating, onClose }: StudyPanelProps)
         )}
 
         {artifact && (artifact.type === 'notes' || artifact.type === 'study_guide') && (
-          <EditableNotes content={artifact.content} />
+          <EditableNotes key={artifact.content} content={artifact.content} />
         )}
       </div>
     </div>
@@ -74,12 +74,6 @@ function EditableNotes({ content: initialContent }: { content: string }) {
   const [content, setContent] = useState(initialContent)
   const [isEditing, setIsEditing] = useState(false)
   const textareaRef = useRef<HTMLTextAreaElement>(null)
-
-  // Sync when new content arrives (e.g. new artifact generated)
-  useEffect(() => {
-    setContent(initialContent)
-    setIsEditing(false)
-  }, [initialContent])
 
   // Auto-resize textarea and focus when entering edit mode
   useEffect(() => {

--- a/frontend/src/components/focus/FocusTaskBoard.tsx
+++ b/frontend/src/components/focus/FocusTaskBoard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react'
+import { useState } from 'react'
 import { Plus, X, ChevronLeft, ChevronRight, ClipboardList, Loader, CheckCircle } from 'lucide-react'
 import type { FocusTask, TaskStatus, Priority } from '../../hooks/useFocusTasks'
 
@@ -33,19 +33,6 @@ export function FocusTaskBoard({ tasks, addTask, updateTask, moveTask, deleteTas
   const [targetColumn, setTargetColumn] = useState<TaskStatus>('planned')
   const [pages, setPages] = useState<Record<TaskStatus, number>>({ 'planned': 1, 'in-progress': 1, 'done': 1 })
   const [form, setForm] = useState({ title: '', note: '', priority: 'medium' as Priority })
-
-  // Keep pages in bounds
-  useEffect(() => {
-    setPages(prev => {
-      const next = { ...prev }
-      let changed = false
-      for (const col of columns) {
-        const total = Math.ceil(tasks.filter(t => t.status === col.id).length / ITEMS_PER_PAGE) || 1
-        if (prev[col.id] > total) { next[col.id] = total; changed = true }
-      }
-      return changed ? next : prev
-    })
-  }, [tasks])
 
   const openAdd = (col: TaskStatus) => {
     setEditingId(null)

--- a/frontend/src/hooks/useFocusMusic.ts
+++ b/frontend/src/hooks/useFocusMusic.ts
@@ -70,7 +70,7 @@ export function useFocusMusic() {
   const [isMuted, setIsMuted] = useState(false)
   const [currentTime, setCurrentTime] = useState(0)
   const [duration, setDuration] = useState(0)
-  const [playerReady, setPlayerReady] = useState(false)
+  const [playerReady, setPlayerReady] = useState(() => !!(window.YT && window.YT.Player))
   const [activeCategory, setActiveCategory] = useState<MusicCategory | null>(null)
 
   const playerRef = useRef<any>(null)
@@ -82,10 +82,7 @@ export function useFocusMusic() {
 
   // Load YouTube IFrame API
   useEffect(() => {
-    if (window.YT && window.YT.Player) {
-      setPlayerReady(true)
-      return
-    }
+    if (window.YT && window.YT.Player) return
     if (!document.querySelector('script[src*="youtube.com/iframe_api"]')) {
       const tag = document.createElement('script')
       tag.src = 'https://www.youtube.com/iframe_api'

--- a/frontend/src/hooks/useFocusMusic.ts
+++ b/frontend/src/hooks/useFocusMusic.ts
@@ -55,10 +55,38 @@ const PLAYLISTS: Record<MusicCategory, MusicTrack[]> = {
   ],
 }
 
+interface YTPlayer {
+  setVolume(volume: number): void
+  getVolume(): number
+  getCurrentTime(): number
+  getDuration(): number
+  getPlayerState(): number
+  loadVideoById(videoId: string): void
+  playVideo(): void
+  pauseVideo(): void
+  seekTo(seconds: number, allowSeekAhead: boolean): void
+}
+
+interface YTPlayerEvent {
+  data: number
+}
+
+interface YTPlayerConfig {
+  height: string | number
+  width: string | number
+  playerVars?: Record<string, number>
+  events?: {
+    onReady?: () => void
+    onStateChange?: (event: YTPlayerEvent) => void
+  }
+}
+
 declare global {
   interface Window {
-    YT: any
-    onYouTubeIframeAPIReady: () => void
+    YT?: {
+      Player: new (elementId: string, config: YTPlayerConfig) => YTPlayer
+    }
+    onYouTubeIframeAPIReady?: () => void
   }
 }
 
@@ -73,7 +101,7 @@ export function useFocusMusic() {
   const [playerReady, setPlayerReady] = useState(() => !!(window.YT && window.YT.Player))
   const [activeCategory, setActiveCategory] = useState<MusicCategory | null>(null)
 
-  const playerRef = useRef<any>(null)
+  const playerRef = useRef<YTPlayer | null>(null)
   const playlistRef = useRef<MusicTrack[]>([])
   const indexRef = useRef(0)
 
@@ -104,13 +132,14 @@ export function useFocusMusic() {
       div.style.display = 'none'
       document.body.appendChild(div)
     }
+    if (!window.YT) return
     playerRef.current = new window.YT.Player('docere-yt-player', {
       height: '0',
       width: '0',
       playerVars: { autoplay: 0, controls: 0, disablekb: 1, enablejsapi: 1, fs: 0, modestbranding: 1, playsinline: 1, rel: 0 },
       events: {
         onReady: () => { playerRef.current?.setVolume(volume) },
-        onStateChange: (e: any) => {
+        onStateChange: (e: YTPlayerEvent) => {
           if (e.data === 0 && playlistRef.current.length > 0) {
             const next = (indexRef.current + 1) % playlistRef.current.length
             setCurrentTrackIndex(next)

--- a/frontend/src/hooks/useFocusTimer.ts
+++ b/frontend/src/hooks/useFocusTimer.ts
@@ -28,6 +28,7 @@ export function useFocusTimer() {
   // Update pomoTime when durations change (if not running)
   useEffect(() => {
     if (!isRunning) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs idle pomoTime to the current duration settings, not derivable at render since pomoTime is also mutated by the tick interval
       if (pomoMode === 'focus') setPomoTime(focusDuration * 60)
       else if (pomoMode === 'shortBreak') setPomoTime(shortBreakDuration * 60)
       else if (pomoMode === 'longBreak') setPomoTime(longBreakDuration * 60)

--- a/frontend/src/hooks/useTypewriter.ts
+++ b/frontend/src/hooks/useTypewriter.ts
@@ -28,14 +28,19 @@ export function useTypewriter({
   // Speed up for long content
   const speed = text.length > 3000 ? 5 : charsPerTick
 
-  const isComplete = !enabled || skipped || charIndex >= text.length
-
-  useEffect(() => {
-    // Reset when text changes
+  // Reset when text changes (adjusting state during render, per react.dev)
+  const [prevText, setPrevText] = useState(text)
+  if (text !== prevText) {
+    setPrevText(text)
     setCharIndex(0)
     setSkipped(false)
+  }
+
+  useEffect(() => {
     lastTickRef.current = 0
   }, [text])
+
+  const isComplete = !enabled || skipped || charIndex >= text.length
 
   useEffect(() => {
     if (!enabled || skipped || charIndex >= text.length) return

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -81,15 +81,12 @@ export function ChatPage() {
 
   const activeConv = conversations.find(c => c.id === activeConvId)
 
-  // Load/save notes from localStorage per conversation
-  useEffect(() => {
-    if (activeConvId) {
-      const saved = localStorage.getItem(`docere-notes-${activeConvId}`)
-      setNotesContent(saved || '')
-    } else {
-      setNotesContent('')
-    }
-  }, [activeConvId])
+  // Load notes from localStorage when switching conversations (adjusting state during render)
+  const [notesConvId, setNotesConvId] = useState(activeConvId)
+  if (activeConvId !== notesConvId) {
+    setNotesConvId(activeConvId)
+    setNotesContent(activeConvId ? localStorage.getItem(`docere-notes-${activeConvId}`) || '' : '')
+  }
 
   const handleNotesChange = (value: string) => {
     setNotesContent(value)

--- a/frontend/src/pages/ChatPage.tsx
+++ b/frontend/src/pages/ChatPage.tsx
@@ -239,7 +239,7 @@ export function ChatPage() {
     setIsMeetingPanelOpen(false)
   }
 
-  const handleSendMessage = async (content: string, _files?: File[]) => {
+  const handleSendMessage = async (content: string) => {
     // Course for new conversations: toggled pill > active conversation > first course
     const courseId = activeCourseId || activeConv?.courseId || (courses.length > 0 ? courses[0].id : null)
     if (!courseId) return
@@ -444,7 +444,7 @@ export function ChatPage() {
             } else if (isStudyRequest) {
               closePanel()
             }
-          } catch (fallbackErr) {
+          } catch {
             setIsLoading(false)
             setIsGeneratingArtifact(false)
             if (isStudyRequest) closePanel()

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -120,8 +120,8 @@ export function CollectionsPage({ courseId, onClose }: Props) {
       setUploadProgress(100)
       await loadDocs()
       setTimeout(() => setActiveDocId(result.doc_id), 200)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Upload failed')
     } finally {
       setUploading(false)
     }
@@ -144,8 +144,8 @@ export function CollectionsPage({ courseId, onClose }: Props) {
       setShowUrlInput(false)
       await loadDocs()
       setActiveDocId(result.doc_id)
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Upload failed')
     } finally {
       setUploading(false)
     }
@@ -158,8 +158,8 @@ export function CollectionsPage({ courseId, onClose }: Props) {
       await api.deleteDocument(docId)
       if (activeDocId === docId) setActiveDocId(null)
       setDocs(prev => prev.filter(d => d.id !== docId))
-    } catch (e: any) {
-      setError(e.message)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Delete failed')
     }
   }
 

--- a/frontend/src/pages/CollectionsPage.tsx
+++ b/frontend/src/pages/CollectionsPage.tsx
@@ -1,8 +1,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from 'react'
 import {
-  X, Upload, FileText, Trash2, CheckCircle, AlertCircle, Loader,
+  X, Upload, FileText, Trash2, AlertCircle, Loader,
   Link, BookOpen, Search, Grid3X3, List, File, Image, Presentation,
-  Table, MoreVertical, Clock, HardDrive, Eye, Plus
+  Table, Eye, Plus
 } from 'lucide-react'
 import { DocumentReader } from '../components/DocumentReader'
 import * as api from '../api'
@@ -70,7 +70,7 @@ export function CollectionsPage({ courseId, onClose }: Props) {
   const [searchQuery, setSearchQuery] = useState('')
   const [viewMode, setViewMode] = useState<ViewMode>('grid')
   const [dragOver, setDragOver] = useState(false)
-  const [contextMenu, setContextMenu] = useState<string | null>(null)
+  const [, setContextMenu] = useState<string | null>(null)
   const fileRef = useRef<HTMLInputElement>(null)
   const contextRef = useRef<HTMLDivElement>(null)
 

--- a/frontend/src/pages/InstructorDashboardPage.tsx
+++ b/frontend/src/pages/InstructorDashboardPage.tsx
@@ -375,6 +375,7 @@ export function InstructorDashboardPage() {
     const pathParts = window.location.pathname.split('/')
     const cid = pathParts[pathParts.length - 1]
     if (!cid) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time synchronous parse of the mount-time URL path, not derivable from props/state
       setError('No course specified')
       setLoading(false)
       return

--- a/frontend/src/pages/InstructorDashboardPage.tsx
+++ b/frontend/src/pages/InstructorDashboardPage.tsx
@@ -11,7 +11,7 @@ import { useInstructorChat } from '../hooks/useInstructorChat'
 import { useMetaChat } from '../hooks/useMetaChat'
 import { CalendarSetup } from '../components/CalendarSetup'
 import { ActionCard } from '../components/ActionCard'
-import { GmailModal, GoogleDocsModal, GoogleSheetsModal, ExcelModal, CalendarEventModal, LMSAnnouncementModal } from '../components/ToolModals'
+import { GmailModal, GoogleDocsModal, CalendarEventModal, LMSAnnouncementModal } from '../components/ToolModals'
 import { GradebookSyncModal } from '../components/GradebookSyncModal'
 
 interface DashboardSummary {

--- a/frontend/src/pages/LTICallbackPage.tsx
+++ b/frontend/src/pages/LTICallbackPage.tsx
@@ -14,6 +14,7 @@ export function LTICallbackPage() {
     try {
       const hash = window.location.hash.substring(1) // remove '#'
       if (!hash) {
+        // eslint-disable-next-line react-hooks/set-state-in-effect -- one-time synchronous parse of the mount-time URL hash, not derivable from props/state
         setError('No authentication data in URL')
         return
       }

--- a/frontend/src/pages/MemoryMapPage.tsx
+++ b/frontend/src/pages/MemoryMapPage.tsx
@@ -116,8 +116,8 @@ export function MemoryMapPage({ courseId, onClose }: Props) {
       // Auto-confirm (skip preview, add directly)
       await loadDocs()
       await loadGraph()
-    } catch (e: any) {
-      setUploadError(e.message)
+    } catch (e) {
+      setUploadError(e instanceof Error ? e.message : 'Upload failed')
     } finally {
       setUploading(false)
     }
@@ -133,8 +133,8 @@ export function MemoryMapPage({ courseId, onClose }: Props) {
       setShowUrlInput(false)
       await loadDocs()
       await loadGraph()
-    } catch (e: any) {
-      setUploadError(e.message)
+    } catch (e) {
+      setUploadError(e instanceof Error ? e.message : 'Upload failed')
     } finally {
       setUploading(false)
     }


### PR DESCRIPTION
Fixes both `frontend-build` and `frontend-lint` jobs. Both pass on this branch.
Closes #37 

## What was done

| Phase | What |
|---|---|
| 1 | Changed CI type-check step from `tsc --noEmit` to `tsc -b --noEmit` |
| 2 | Fixed 40 `tsc -b` build errors across 12 files: Tiptap v3 API, `@types/three` install, React 19 `useRef` overloads, status enum bug in `DocumentsPanel.tsx`, assorted unused imports |
| 3a | Mechanical ESLint fixes (27 errors): `no-empty` (`allowEmptyCatch`), `react-refresh/only-export-components` (`allowExportNames`), unused vars, `react-hooks/purity`, `react-hooks/rules-of-hooks`, hoisted `ToolbarButton` in `NotesEditor.tsx` |
| 3b | Fixed all 50 `@typescript-eslint/no-explicit-any` errors. `ConceptGraph3D.tsx` and `StudentMemoryGraph.tsx` (30 of 50) got proper discriminated-union scene-node types using `NodeObject`/`LinkObject` from `react-force-graph-3d`. The remaining 20 (`catch (e: any)` patterns across 7 files) were converted to the repo's `e instanceof Error ? e.message : 'fallback'` convention |
| 3c | Fixed 12 `react-hooks/set-state-in-effect` errors (new v7 rule). Removed redundant synchronous `setState` calls, moved one-time URL parsing to narrow `eslint-disable` comments, switched two components to the "adjust state during render" pattern |

## Out of scope

The 5 `react-hooks/exhaustive-deps` warnings are pre-existing and do not fail `npm run lint` (no `--max-warnings`). Left as-is for a future pass.

## Verification

```bash
npm run lint    # 0 errors, 5 warnings
npm run build   # tsc -b + vite build pass
```
